### PR TITLE
Change of the ruleset for tests (required for #1090)

### DIFF
--- a/SixLabors.Tests.ruleset
+++ b/SixLabors.Tests.ruleset
@@ -50,6 +50,15 @@
     <!--Comments should end with a period. I like this but there's 3000+ errors to fix in ImageSharp-->
     <Rule Id="SA1629" Action="None" />
 
+    <!--The XML documentation header for a C# constructor does not contain the appropriate summary text.-->
+    <Rule Id="SA1642" Action="None" />
+
+    <!--Constructor is missing documentation for one or more of its parameters.-->
+    <Rule Id="SA1611" Action="None" />
+
+    <!--Parameter must follow comma.-->
+    <Rule Id="SA1115" Action="None" />
+
     <!--A C# code file is missing a standard file header.-->
     <Rule Id="SA1633" Action="Warning" />
 


### PR DESCRIPTION
This will disable the following rules:

- **SA1642**: The XML documentation header for a C# constructor does not contain the appropriate summary text. Reason: Standard constructor text is usually not very helpful.

- **SA1611**: Constructor is missing documentation for one or more of its parameters. Reason: To many  undocumented parameters in the tests, bit still some useful summary text, so deleting both would remove at least some useful info.

- **SA1115**: Parameter must follow comma. Reason: This rule sometimes conflicts with comment rules. 