### PR TITLE
Remove unused NuGet license file

### DIFF
--- a/NUGETLICENSE.md
+++ b/NUGETLICENSE.md
@@ -1,6 +1,0 @@
-﻿# License
-  
-- The source code for this package is licensed under the [GNU Affero General Public License v3](https://www.gnu.org/licenses/agpl-3.0)  
-- An alternative Commercial License can be purchased for Closed Source projects and applications.
-Please visit https://sixlabors.com/pricing for details.
-- Open Source projects who have taken a dependency on versions of this package prior to adoption of the AGPL v3 license are permitted to use this package (including all future versions) under the previous [Apache 2.0 License](https://opensource.org/licenses/Apache-2.0).


### PR DESCRIPTION
Noticed an inconsistency with the licensing of the repo and this file. The text I've used is derived from the license in the ImageSharp readme.

If I've misunderstood the licensing for this repo and have inadvertently changed it from what you intended, feel free to close this. 🙂