### PR TITLE
Improved Guard APIs codegen

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: SixLabors
+open_collective: sixlabors

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### Prerequisites
+
+- [ ] I have written a descriptive pull-request title
+- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/SharedInfrastructure/pulls) open
+- [ ] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
+- [ ] I have provided test coverage for my change (where applicable)
+
+### Description
+<!-- A description of the changes proposed in the pull-request -->
+
+<!-- Thanks for contributing to SharedInfrastructure! -->

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,11 +25,23 @@ jobs:
                       runtime: -x64
                       codecov: false
                     - os: windows-latest
+                      framework: netcoreapp2.0
+                      runtime: -x64
+                      codecov: false
+                    - os: windows-latest
                       framework: net472
                       runtime: -x64
                       codecov: false
                     - os: windows-latest
                       framework: net472
+                      runtime: -x86
+                      codecov: false
+                    - os: windows-latest
+                      framework: net46
+                      runtime: -x64
+                      codecov: false
+                    - os: windows-latest
+                      framework: net46
                       runtime: -x86
                       codecov: false
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,68 @@
+name: Build
+
+on:
+    push:
+        branches:
+            - master
+    pull_request:
+        branches:
+            - master
+jobs:
+    Build:
+        strategy:
+            matrix:
+                options:
+                    - os: ubuntu-latest
+                      framework: netcoreapp3.1
+                      runtime: -x64
+                      codecov: false
+                    - os: windows-latest
+                      framework: netcoreapp3.1
+                      runtime: -x64
+                      codecov: true
+                    - os: windows-latest
+                      framework: netcoreapp2.1
+                      runtime: -x64
+                      codecov: false
+                    - os: windows-latest
+                      framework: net472
+                      runtime: -x64
+                      codecov: false
+                    - os: windows-latest
+                      framework: net472
+                      runtime: -x86
+                      codecov: false
+
+        runs-on: ${{matrix.options.os}}
+        if: "!contains(github.event.head_commit.message, '[skip ci]')"
+
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Install NuGet
+              uses: NuGet/setup-nuget@v1
+
+            - name: Setup Git
+              shell: bash
+              run: |
+                  git config --global core.autocrlf false
+                  git config --global core.longpaths true
+                  git fetch --prune --unshallow
+                  git submodule -q update --init --recursive
+
+            - name: Build
+              shell: pwsh
+              run: ./ci-build.ps1 "${{matrix.options.framework}}"
+
+            - name: Test
+              shell: pwsh
+              run: ./ci-test.ps1 "${{matrix.options.os}}" "${{matrix.options.framework}}" "${{matrix.options.runtime}}" "${{matrix.options.codecov}}"
+              env:
+                  CI: True
+                  XUNIT_PATH: .\tests\SharedInfrastructure.Tests # Required for xunit
+
+            - name: Update Codecov
+              uses: codecov/codecov-action@v1
+              if: matrix.options.codecov == true && startsWith(github.repository, 'SixLabors')
+              with:
+                  flags: unittests

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 SixLabors.SharedInfrastructure
 </h1>
 
+<div align="center">
+
+[![Build Status](https://img.shields.io/github/workflow/status/SixLabors/SharedInfrastructure/Build/master)](https://github.com/SixLabors/SharedInfrastructure/actions)
+[![Code coverage](https://codecov.io/gh/SixLabors/SharedInfrastructure/branch/master/graph/badge.svg)](https://codecov.io/gh/SixLabors/SharedInfrastructure)
+[![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+</div>
+
 This repository contains:
 - Configuration and guidelines for automated linting of C# projects.
 - Standardized internal C# utility classes to be reused across SixLabors projects (like `Guard`, `MathF`, and `HashCode`)
@@ -143,29 +151,61 @@ An up-to-date list of which StyleCop rules are implemented and which have code f
 To include internals like `Guard.cs`, `MathF`, and `HashCode` into your project you should add configuration like the following to your `.csproj`:
 
 ``` xml
-<PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-  <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_HASHCODE;SUPPORTS_EXTENDED_INTRINSICS;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING;SUPPORTS_RUNTIME_INTRINSICS;SUPPORTS_CODECOVERAGE;SUPPORTS_HOTPATH</DefineConstants>
-</PropertyGroup>
+  <!--
+    https://apisof.net/
+    +===================+=======+==========+=====================+=============+=================+====================+==============+=========+============|
+    | SUPPORTS          | MATHF | HASHCODE | EXTENDED_INTRINSICS | SPAN_STREAM | ENCODING_STRING | RUNTIME_INTRINSICS | CODECOVERAGE | HOTPATH | CREATESPAN |
+    +===================+=======+==========+=====================+=============+=================+====================+==============+=========|============|
+    | netcoreapp3.1     |   Y   |    Y     |         Y           |      Y      |        Y        |        Y           |      Y       |    Y    |      Y     |
+    | netcoreapp2.1     |   Y   |    Y     |         Y           |      Y      |        Y        |        N           |      Y       |    N    |      Y     |
+    | netcoreapp2.0     |   Y   |    N     |         N           |      N      |        N        |        N           |      Y       |    N    |      Y     |
+    | netstandard2.1    |   Y   |    Y     |         N           |      Y      |        Y        |        N           |      Y       |    N    |      Y     |
+    | netstandard2.0    |   N   |    N     |         N           |      N      |        N        |        N           |      Y       |    N    |      N     |
+    | netstandard1.3    |   N   |    N     |         N           |      N      |        N        |        N           |      N       |    N    |      N     |
+    | net472            |   N   |    N     |         Y           |      N      |        N        |        N           |      Y       |    N    |      N     |
+    +===================+=======+==========+=====================+=============+=================+====================+==============+=========|============|
+    -->
 
-<PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-  <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_HASHCODE;SUPPORTS_EXTENDED_INTRINSICS;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING;SUPPORTS_CODECOVERAGE</DefineConstants>
-</PropertyGroup>
-
-<PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-  <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_CODECOVERAGE</DefineConstants>
-</PropertyGroup>
-
-<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-  <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_HASHCODE;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING;SUPPORTS_CODECOVERAGE</DefineConstants>
-</PropertyGroup>
-
-<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-  <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
-</PropertyGroup>
-
-<PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
-  <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS;SUPPORTS_CODECOVERAGE</DefineConstants>
-</PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_HASHCODE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_SPAN_STREAM</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_ENCODING_STRING</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_RUNTIME_INTRINSICS</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_HOTPATH</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_CREATESPAN</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_HASHCODE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_SPAN_STREAM</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_ENCODING_STRING</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_CREATESPAN</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_CREATESPAN</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_HASHCODE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_SPAN_STREAM</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_ENCODING_STRING</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_CREATESPAN</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
+    <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
+  </PropertyGroup>
 ```  
   
 And add the `SharedInfrastructure.shproj` as a project dependency.

--- a/SharedInfrastructure.sln
+++ b/SharedInfrastructure.sln
@@ -7,17 +7,38 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharedInfrastructure.Tests"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "SharedInfrastructure", "src\SharedInfrastructure\SharedInfrastructure.shproj", "{68A8CC40-6AED-4E96-B524-31B1158FDEEA}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{27502888-A75B-4BCB-8D19-C81198AEF7C7}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_root", "_root", "{27502888-A75B-4BCB-8D19-C81198AEF7C7}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
+		ci-build.ps1 = ci-build.ps1
+		ci-test.ps1 = ci-test.ps1
+		codecov.yml = codecov.yml
 		LICENSE = LICENSE
 		README.md = README.md
 		SixLabors.ruleset = SixLabors.ruleset
 		SixLabors.snk = SixLabors.snk
 		SixLabors.Tests.ruleset = SixLabors.Tests.ruleset
 		stylecop.json = stylecop.json
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{91A98DCB-FA23-444B-865A-3734578F1C28}"
+	ProjectSection(SolutionItems) = preProject
+		.github\FUNDING.yml = .github\FUNDING.yml
+		.github\PULL_REQUEST_TEMPLATE.md = .github\PULL_REQUEST_TEMPLATE.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{B3C84CC9-D0F5-4D9F-93A8-D742A73F3674}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\build-and-test.yml = .github\workflows\build-and-test.yml
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{07706BC0-CA04-4558-A005-3F9FA7D9933C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{478B60EE-3651-4B39-83BD-528C428AC628}"
+	ProjectSection(SolutionItems) = preProject
+		tests\coverlet.runsettings = tests\coverlet.runsettings
 	EndProjectSection
 EndProject
 Global
@@ -37,6 +58,12 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{1664B46A-D99F-4C66-9424-A3A17C926A4C} = {478B60EE-3651-4B39-83BD-528C428AC628}
+		{68A8CC40-6AED-4E96-B524-31B1158FDEEA} = {07706BC0-CA04-4558-A005-3F9FA7D9933C}
+		{91A98DCB-FA23-444B-865A-3734578F1C28} = {27502888-A75B-4BCB-8D19-C81198AEF7C7}
+		{B3C84CC9-D0F5-4D9F-93A8-D742A73F3674} = {91A98DCB-FA23-444B-865A-3734578F1C28}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CDD6BE8E-01A1-4A70-AA7E-F1D64E8FA829}

--- a/ci-build.ps1
+++ b/ci-build.ps1
@@ -1,0 +1,11 @@
+param(
+  [Parameter(Mandatory = $true, Position = 0)]
+  [string]$targetFramework
+)
+
+dotnet clean -c Release
+
+$repositoryUrl = "https://github.com/$env:GITHUB_REPOSITORY"
+
+# Building for a specific framework.
+dotnet build -c Release -f $targetFramework /p:RepositoryUrl=$repositoryUrl

--- a/ci-test.ps1
+++ b/ci-test.ps1
@@ -1,0 +1,37 @@
+param(
+  [Parameter(Mandatory, Position = 0)]
+  [string]$os,
+  [Parameter(Mandatory, Position = 1)]
+  [string]$targetFramework,
+  [Parameter(Mandatory, Position = 2)]
+  [string]$platform,
+  [Parameter(Mandatory, Position = 3)]
+  [string]$codecov,
+  [Parameter(Position = 4)]
+  [string]$codecovProfile = 'Release'
+)
+
+$netFxRegex = '^net\d+'
+
+if ($codecov -eq 'true') {
+
+  # Allow toggling of profile to workaround any potential JIT errors caused by code injection.
+  dotnet clean -c $codecovProfile
+  dotnet test --collect "XPlat Code Coverage" --settings .\tests\coverlet.runsettings -c $codecovProfile -f $targetFramework /p:CodeCov=true
+}
+elseif ($platform -eq '-x86' -and $targetFramework -match $netFxRegex) {
+
+  # xunit doesn't run on core with NET SDK 3.1+.
+  # xunit doesn't actually understand -x64 as an option.
+  #
+  # xunit requires explicit path.
+  Set-Location $env:XUNIT_PATH
+
+  dotnet xunit --no-build -c Release -f $targetFramework ${fxVersion} $platform
+
+  Set-Location $PSScriptRoot
+}
+else {
+
+  dotnet test --no-build -c Release -f $targetFramework
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+# Documentation: https://docs.codecov.io/docs/codecov-yaml
+
+codecov:
+    # Avoid "Missing base report"
+    # https://github.com/codecov/support/issues/363
+    # https://docs.codecov.io/docs/comparing-commits
+    allow_coverage_offsets: true
+
+    # Avoid Report Expired
+    # https://docs.codecov.io/docs/codecov-yaml#section-expired-reports
+    max_report_age: off

--- a/src/SharedInfrastructure/DebugGuard.cs
+++ b/src/SharedInfrastructure/DebugGuard.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace SixLabors
@@ -12,9 +11,6 @@ namespace SixLabors
     /// Provides methods to protect against invalid parameters for a DEBUG build.
     /// </summary>
     [DebuggerStepThrough]
-#pragma warning disable CS0436 // Type conflicts with imported type
-    [ExcludeFromCodeCoverage]
-#pragma warning restore CS0436 // Type conflicts with imported type
     internal static partial class DebugGuard
     {
         /// <summary>

--- a/src/SharedInfrastructure/Guard.Numeric.cs
+++ b/src/SharedInfrastructure/Guard.Numeric.cs
@@ -23,10 +23,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThan(byte value, byte max, string parameterName)
         {
-            if (value >= max)
+            if (value < max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
         }
 
         /// <summary>
@@ -42,10 +44,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThanOrEqualTo(byte value, byte max, string parameterName)
         {
-            if (value > max)
+            if (value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
         }
 
         /// <summary>
@@ -61,10 +65,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThan(byte value, byte min, string parameterName)
         {
-            if (value <= min)
+            if (value > min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
         }
 
         /// <summary>
@@ -80,10 +86,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThanOrEqualTo(byte value, byte min, string parameterName)
         {
-            if (value < min)
+            if (value >= min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
         }
 
         /// <summary>
@@ -100,10 +108,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeBetweenOrEqualTo(byte value, byte min, byte max, string parameterName)
         {
-            if (value < min || value > max)
+            if (value >= min && value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
         }
 
         /// <summary>
@@ -118,10 +128,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThan(sbyte value, sbyte max, string parameterName)
         {
-            if (value >= max)
+            if (value < max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
         }
 
         /// <summary>
@@ -137,10 +149,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThanOrEqualTo(sbyte value, sbyte max, string parameterName)
         {
-            if (value > max)
+            if (value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
         }
 
         /// <summary>
@@ -156,10 +170,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThan(sbyte value, sbyte min, string parameterName)
         {
-            if (value <= min)
+            if (value > min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
         }
 
         /// <summary>
@@ -175,10 +191,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThanOrEqualTo(sbyte value, sbyte min, string parameterName)
         {
-            if (value < min)
+            if (value >= min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
         }
 
         /// <summary>
@@ -195,10 +213,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeBetweenOrEqualTo(sbyte value, sbyte min, sbyte max, string parameterName)
         {
-            if (value < min || value > max)
+            if (value >= min && value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
         }
 
         /// <summary>
@@ -213,10 +233,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThan(short value, short max, string parameterName)
         {
-            if (value >= max)
+            if (value < max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
         }
 
         /// <summary>
@@ -232,10 +254,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThanOrEqualTo(short value, short max, string parameterName)
         {
-            if (value > max)
+            if (value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
         }
 
         /// <summary>
@@ -251,10 +275,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThan(short value, short min, string parameterName)
         {
-            if (value <= min)
+            if (value > min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
         }
 
         /// <summary>
@@ -270,10 +296,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThanOrEqualTo(short value, short min, string parameterName)
         {
-            if (value < min)
+            if (value >= min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
         }
 
         /// <summary>
@@ -290,10 +318,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeBetweenOrEqualTo(short value, short min, short max, string parameterName)
         {
-            if (value < min || value > max)
+            if (value >= min && value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
         }
 
         /// <summary>
@@ -308,10 +338,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThan(ushort value, ushort max, string parameterName)
         {
-            if (value >= max)
+            if (value < max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
         }
 
         /// <summary>
@@ -327,10 +359,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThanOrEqualTo(ushort value, ushort max, string parameterName)
         {
-            if (value > max)
+            if (value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
         }
 
         /// <summary>
@@ -346,10 +380,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThan(ushort value, ushort min, string parameterName)
         {
-            if (value <= min)
+            if (value > min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
         }
 
         /// <summary>
@@ -365,10 +401,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThanOrEqualTo(ushort value, ushort min, string parameterName)
         {
-            if (value < min)
+            if (value >= min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
         }
 
         /// <summary>
@@ -385,10 +423,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeBetweenOrEqualTo(ushort value, ushort min, ushort max, string parameterName)
         {
-            if (value < min || value > max)
+            if (value >= min && value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
         }
 
         /// <summary>
@@ -403,10 +443,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThan(char value, char max, string parameterName)
         {
-            if (value >= max)
+            if (value < max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
         }
 
         /// <summary>
@@ -422,10 +464,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThanOrEqualTo(char value, char max, string parameterName)
         {
-            if (value > max)
+            if (value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
         }
 
         /// <summary>
@@ -441,10 +485,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThan(char value, char min, string parameterName)
         {
-            if (value <= min)
+            if (value > min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
         }
 
         /// <summary>
@@ -460,10 +506,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThanOrEqualTo(char value, char min, string parameterName)
         {
-            if (value < min)
+            if (value >= min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
         }
 
         /// <summary>
@@ -480,10 +528,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeBetweenOrEqualTo(char value, char min, char max, string parameterName)
         {
-            if (value < min || value > max)
+            if (value >= min && value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
         }
 
         /// <summary>
@@ -498,10 +548,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThan(int value, int max, string parameterName)
         {
-            if (value >= max)
+            if (value < max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
         }
 
         /// <summary>
@@ -517,10 +569,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThanOrEqualTo(int value, int max, string parameterName)
         {
-            if (value > max)
+            if (value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
         }
 
         /// <summary>
@@ -536,10 +590,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThan(int value, int min, string parameterName)
         {
-            if (value <= min)
+            if (value > min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
         }
 
         /// <summary>
@@ -555,10 +611,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThanOrEqualTo(int value, int min, string parameterName)
         {
-            if (value < min)
+            if (value >= min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
         }
 
         /// <summary>
@@ -575,10 +633,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeBetweenOrEqualTo(int value, int min, int max, string parameterName)
         {
-            if (value < min || value > max)
+            if (value >= min && value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
         }
 
         /// <summary>
@@ -593,10 +653,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThan(uint value, uint max, string parameterName)
         {
-            if (value >= max)
+            if (value < max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
         }
 
         /// <summary>
@@ -612,10 +674,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThanOrEqualTo(uint value, uint max, string parameterName)
         {
-            if (value > max)
+            if (value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
         }
 
         /// <summary>
@@ -631,10 +695,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThan(uint value, uint min, string parameterName)
         {
-            if (value <= min)
+            if (value > min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
         }
 
         /// <summary>
@@ -650,10 +716,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThanOrEqualTo(uint value, uint min, string parameterName)
         {
-            if (value < min)
+            if (value >= min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
         }
 
         /// <summary>
@@ -670,10 +738,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeBetweenOrEqualTo(uint value, uint min, uint max, string parameterName)
         {
-            if (value < min || value > max)
+            if (value >= min && value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
         }
 
         /// <summary>
@@ -688,10 +758,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThan(float value, float max, string parameterName)
         {
-            if (value >= max)
+            if (value < max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
         }
 
         /// <summary>
@@ -707,10 +779,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThanOrEqualTo(float value, float max, string parameterName)
         {
-            if (value > max)
+            if (value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
         }
 
         /// <summary>
@@ -726,10 +800,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThan(float value, float min, string parameterName)
         {
-            if (value <= min)
+            if (value > min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
         }
 
         /// <summary>
@@ -745,10 +821,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThanOrEqualTo(float value, float min, string parameterName)
         {
-            if (value < min)
+            if (value >= min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
         }
 
         /// <summary>
@@ -765,10 +843,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeBetweenOrEqualTo(float value, float min, float max, string parameterName)
         {
-            if (value < min || value > max)
+            if (value >= min && value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
         }
 
         /// <summary>
@@ -783,10 +863,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThan(long value, long max, string parameterName)
         {
-            if (value >= max)
+            if (value < max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
         }
 
         /// <summary>
@@ -802,10 +884,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThanOrEqualTo(long value, long max, string parameterName)
         {
-            if (value > max)
+            if (value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
         }
 
         /// <summary>
@@ -821,10 +905,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThan(long value, long min, string parameterName)
         {
-            if (value <= min)
+            if (value > min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
         }
 
         /// <summary>
@@ -840,10 +926,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThanOrEqualTo(long value, long min, string parameterName)
         {
-            if (value < min)
+            if (value >= min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
         }
 
         /// <summary>
@@ -860,10 +948,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeBetweenOrEqualTo(long value, long min, long max, string parameterName)
         {
-            if (value < min || value > max)
+            if (value >= min && value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
         }
 
         /// <summary>
@@ -878,10 +968,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThan(ulong value, ulong max, string parameterName)
         {
-            if (value >= max)
+            if (value < max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
         }
 
         /// <summary>
@@ -897,10 +989,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThanOrEqualTo(ulong value, ulong max, string parameterName)
         {
-            if (value > max)
+            if (value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
         }
 
         /// <summary>
@@ -916,10 +1010,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThan(ulong value, ulong min, string parameterName)
         {
-            if (value <= min)
+            if (value > min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
         }
 
         /// <summary>
@@ -935,10 +1031,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThanOrEqualTo(ulong value, ulong min, string parameterName)
         {
-            if (value < min)
+            if (value >= min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
         }
 
         /// <summary>
@@ -955,10 +1053,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeBetweenOrEqualTo(ulong value, ulong min, ulong max, string parameterName)
         {
-            if (value < min || value > max)
+            if (value >= min && value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
         }
 
         /// <summary>
@@ -973,10 +1073,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThan(double value, double max, string parameterName)
         {
-            if (value >= max)
+            if (value < max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
         }
 
         /// <summary>
@@ -992,10 +1094,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThanOrEqualTo(double value, double max, string parameterName)
         {
-            if (value > max)
+            if (value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
         }
 
         /// <summary>
@@ -1011,10 +1115,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThan(double value, double min, string parameterName)
         {
-            if (value <= min)
+            if (value > min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
         }
 
         /// <summary>
@@ -1030,10 +1136,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThanOrEqualTo(double value, double min, string parameterName)
         {
-            if (value < min)
+            if (value >= min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
         }
 
         /// <summary>
@@ -1050,10 +1158,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeBetweenOrEqualTo(double value, double min, double max, string parameterName)
         {
-            if (value < min || value > max)
+            if (value >= min && value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
         }
 
         /// <summary>
@@ -1068,10 +1178,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThan(decimal value, decimal max, string parameterName)
         {
-            if (value >= max)
+            if (value < max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
         }
 
         /// <summary>
@@ -1087,10 +1199,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThanOrEqualTo(decimal value, decimal max, string parameterName)
         {
-            if (value > max)
+            if (value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
         }
 
         /// <summary>
@@ -1106,10 +1220,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThan(decimal value, decimal min, string parameterName)
         {
-            if (value <= min)
+            if (value > min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
         }
 
         /// <summary>
@@ -1125,10 +1241,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThanOrEqualTo(decimal value, decimal min, string parameterName)
         {
-            if (value < min)
+            if (value >= min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
         }
 
         /// <summary>
@@ -1145,10 +1263,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeBetweenOrEqualTo(decimal value, decimal min, decimal max, string parameterName)
         {
-            if (value < min || value > max)
+            if (value >= min && value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
         }
     }
 }

--- a/src/SharedInfrastructure/Guard.Numeric.tt.bak
+++ b/src/SharedInfrastructure/Guard.Numeric.tt.bak
@@ -35,10 +35,12 @@ for (var i = 0; i < types.Length; i++)
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThan(<#=T#> value, <#=T#> max, string parameterName)
         {
-            if (value >= max)
+            if (value < max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
         }
 
         /// <summary>
@@ -54,10 +56,12 @@ for (var i = 0; i < types.Length; i++)
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeLessThanOrEqualTo(<#=T#> value, <#=T#> max, string parameterName)
         {
-            if (value > max)
+            if (value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
         }
 
         /// <summary>
@@ -73,10 +77,12 @@ for (var i = 0; i < types.Length; i++)
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThan(<#=T#> value, <#=T#> min, string parameterName)
         {
-            if (value <= min)
+            if (value > min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
         }
 
         /// <summary>
@@ -92,10 +98,12 @@ for (var i = 0; i < types.Length; i++)
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeGreaterThanOrEqualTo(<#=T#> value, <#=T#> min, string parameterName)
         {
-            if (value < min)
+            if (value >= min)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
         }
 
         /// <summary>
@@ -112,10 +120,12 @@ for (var i = 0; i < types.Length; i++)
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeBetweenOrEqualTo(<#=T#> value, <#=T#> min, <#=T#> max, string parameterName)
         {
-            if (value < min || value > max)
+            if (value >= min && value <= max)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
         }
 <#
 }

--- a/src/SharedInfrastructure/Guard.cs
+++ b/src/SharedInfrastructure/Guard.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace SixLabors
@@ -12,9 +11,6 @@ namespace SixLabors
     /// Provides methods to protect against invalid parameters.
     /// </summary>
     [DebuggerStepThrough]
-#pragma warning disable CS0436 // Type conflicts with imported type
-    [ExcludeFromCodeCoverage]
-#pragma warning restore CS0436 // Type conflicts with imported type
     internal static partial class Guard
     {
         /// <summary>

--- a/src/SharedInfrastructure/Guard.cs
+++ b/src/SharedInfrastructure/Guard.cs
@@ -28,10 +28,12 @@ namespace SixLabors
         public static void NotNull<TValue>(TValue value, string parameterName)
             where TValue : class
         {
-            if (value is null)
+            if (!(value is null))
             {
-                ThrowHelper.ThrowArgumentNullExceptionForNotNull(parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentNullExceptionForNotNull(parameterName);
         }
 
         /// <summary>
@@ -44,10 +46,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void NotNullOrWhiteSpace(string value, string parameterName)
         {
-            if (string.IsNullOrWhiteSpace(value))
+            if (!string.IsNullOrWhiteSpace(value))
             {
-                ThrowHelper.ThrowArgumentExceptionForNotNullOrWhitespace(value, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentExceptionForNotNullOrWhitespace(value, parameterName);
         }
 
         /// <summary>
@@ -64,10 +68,12 @@ namespace SixLabors
         public static void MustBeLessThan<TValue>(TValue value, TValue max, string parameterName)
             where TValue : IComparable<TValue>
         {
-            if (value.CompareTo(max) >= 0)
+            if (value.CompareTo(max) < 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThan(value, max, parameterName);
         }
 
         /// <summary>
@@ -85,10 +91,12 @@ namespace SixLabors
         public static void MustBeLessThanOrEqualTo<TValue>(TValue value, TValue max, string parameterName)
             where TValue : IComparable<TValue>
         {
-            if (value.CompareTo(max) > 0)
+            if (value.CompareTo(max) <= 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeLessThanOrEqualTo(value, max, parameterName);
         }
 
         /// <summary>
@@ -106,10 +114,12 @@ namespace SixLabors
         public static void MustBeGreaterThan<TValue>(TValue value, TValue min, string parameterName)
             where TValue : IComparable<TValue>
         {
-            if (value.CompareTo(min) <= 0)
+            if (value.CompareTo(min) > 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThan(value, min, parameterName);
         }
 
         /// <summary>
@@ -127,10 +137,12 @@ namespace SixLabors
         public static void MustBeGreaterThanOrEqualTo<TValue>(TValue value, TValue min, string parameterName)
             where TValue : IComparable<TValue>
         {
-            if (value.CompareTo(min) < 0)
+            if (value.CompareTo(min) >= 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeGreaterThanOrEqualTo(value, min, parameterName);
         }
 
         /// <summary>
@@ -149,10 +161,12 @@ namespace SixLabors
         public static void MustBeBetweenOrEqualTo<TValue>(TValue value, TValue min, TValue max, string parameterName)
             where TValue : IComparable<TValue>
         {
-            if (value.CompareTo(min) < 0 || value.CompareTo(max) > 0)
+            if (value.CompareTo(min) >= 0 && value.CompareTo(max) <= 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeBetweenOrEqualTo(value, min, max, parameterName);
         }
 
         /// <summary>
@@ -168,10 +182,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsTrue(bool target, string parameterName, string message)
         {
-            if (!target)
+            if (target)
             {
-                ThrowHelper.ThrowArgumentException(message, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentException(message, parameterName);
         }
 
         /// <summary>
@@ -187,10 +203,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IsFalse(bool target, string parameterName, string message)
         {
-            if (target)
+            if (!target)
             {
-                ThrowHelper.ThrowArgumentException(message, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentException(message, parameterName);
         }
 
         /// <summary>
@@ -206,10 +224,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeSizedAtLeast<T>(ReadOnlySpan<T> source, int minLength, string parameterName)
         {
-            if (source.Length < minLength)
+            if (source.Length >= minLength)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeSizedAtLeast(minLength, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeSizedAtLeast(minLength, parameterName);
         }
 
         /// <summary>
@@ -225,10 +245,12 @@ namespace SixLabors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void MustBeSizedAtLeast<T>(Span<T> source, int minLength, string parameterName)
         {
-            if (source.Length < minLength)
+            if (source.Length >= minLength)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeSizedAtLeast(minLength, parameterName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentOutOfRangeExceptionForMustBeSizedAtLeast(minLength, parameterName);
         }
 
         /// <summary>
@@ -245,10 +267,12 @@ namespace SixLabors
             Span<TDest> destination,
             string destinationParamName)
         {
-            if (destination.Length < source.Length)
+            if (destination.Length >= source.Length)
             {
-                ThrowHelper.ThrowArgumentException("Destination span is too short!", destinationParamName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentException("Destination span is too short!", destinationParamName);
         }
 
         /// <summary>
@@ -265,10 +289,12 @@ namespace SixLabors
             Span<TDest> destination,
             string destinationParamName)
         {
-            if (destination.Length < source.Length)
+            if (destination.Length >= source.Length)
             {
-                ThrowHelper.ThrowArgumentException("Destination span is too short!", destinationParamName);
+                return;
             }
+
+            ThrowHelper.ThrowArgumentException("Destination span is too short!", destinationParamName);
         }
     }
 }

--- a/src/SharedInfrastructure/MathF.cs
+++ b/src/SharedInfrastructure/MathF.cs
@@ -14,9 +14,6 @@ namespace System
     /// Provides single-precision floating point constants and static methods for trigonometric, logarithmic, and other common mathematical functions.
     /// </summary>
     /// <remarks>MathF emulation on platforms that don't support it natively.</remarks>
-#pragma warning disable CS0436 // Type conflicts with imported type
-    [ExcludeFromCodeCoverage]
-#pragma warning restore CS0436 // Type conflicts with imported type
     internal static class MathF
     {
         /// <summary>

--- a/src/SharedInfrastructure/ThrowHelper.cs
+++ b/src/SharedInfrastructure/ThrowHelper.cs
@@ -9,7 +9,7 @@ namespace SixLabors
     /// <summary>
     /// Helper methods to throw exceptions
     /// </summary>
-    internal static class ThrowHelper
+    internal static partial class ThrowHelper
     {
         /// <summary>
         /// Throws an <see cref="ArgumentNullException"/> when <see cref="Guard.NotNull{TValue}"/> fails.

--- a/tests/SharedInfrastructure.Tests/DebugGuardTests.cs
+++ b/tests/SharedInfrastructure.Tests/DebugGuardTests.cs
@@ -9,9 +9,10 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using SixLabors;
 using Xunit;
 
-namespace SixLabors
+namespace SharedInfrastructure.Tests
 {
     public class DebugGuardTests
     {

--- a/tests/SharedInfrastructure.Tests/GuardTests.cs
+++ b/tests/SharedInfrastructure.Tests/GuardTests.cs
@@ -2,9 +2,10 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using SixLabors;
 using Xunit;
 
-namespace SixLabors
+namespace SharedInfrastructure.Tests
 {
     public class GuardTests
     {

--- a/tests/SharedInfrastructure.Tests/MathFTests.cs
+++ b/tests/SharedInfrastructure.Tests/MathFTests.cs
@@ -4,7 +4,7 @@
 using System;
 using Xunit;
 
-namespace SixLabors
+namespace SharedInfrastructure.Tests
 {
     public class MathFTests
     {

--- a/tests/SharedInfrastructure.Tests/SharedInfrastructure.Tests.csproj
+++ b/tests/SharedInfrastructure.Tests/SharedInfrastructure.Tests.csproj
@@ -2,49 +2,85 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;netcoreapp2.0;net472;net46</TargetFrameworks>
-    <AssemblyName>SixLabors</AssemblyName>
-    <RootNamespace>SixLabors</RootNamespace>
+    <AssemblyName>SharedInfrastructure.Tests</AssemblyName>
+    <RootNamespace>SharedInfrastructure.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
     <CodeAnalysisRuleSet>..\..\SixLabors.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <!--
     https://apisof.net/
-    +===================+=======+==========+=====================+=============+=================+====================+==============+=========|
-    | SUPPORTS          | MATHF | HASHCODE | EXTENDED_INTRINSICS | SPAN_STREAM | ENCODING_STRING | RUNTIME_INTRINSICS | CODECOVERAGE | HOTPATH |
-    +===================+=======+==========+=====================+=============+=================+====================+==============+=========|
-    | netcoreapp3.1     |   Y   |    Y     |         Y           |      Y      |        Y        |        Y           |      Y       |    Y    |
-    | netcoreapp2.1     |   Y   |    Y     |         Y           |      Y      |        Y        |        N           |      Y       |    N    |
-    | netcoreapp2.0     |   Y   |    N     |         N           |      N      |        N        |        N           |      Y       |    N    |
-    | netstandard2.1    |   Y   |    Y     |         N           |      Y      |        Y        |        N           |      Y       |    N    |
-    | netstandard2.0    |   N   |    N     |         N           |      N      |        N        |        N           |      Y       |    N    |
-    | netstandard1.3    |   N   |    N     |         N           |      N      |        N        |        N           |      N       |    N    |
-    | net472            |   N   |    N     |         Y           |      N      |        N        |        N           |      Y       |    N    |
-    +===================+=======+==========+=====================+=============+=================+====================+==============+=========|
+    +===================+=======+==========+=====================+=============+=================+====================+==============+=========+============|
+    | SUPPORTS          | MATHF | HASHCODE | EXTENDED_INTRINSICS | SPAN_STREAM | ENCODING_STRING | RUNTIME_INTRINSICS | CODECOVERAGE | HOTPATH | CREATESPAN |
+    +===================+=======+==========+=====================+=============+=================+====================+==============+=========|============|
+    | netcoreapp3.1     |   Y   |    Y     |         Y           |      Y      |        Y        |        Y           |      Y       |    Y    |      Y     |
+    | netcoreapp2.1     |   Y   |    Y     |         Y           |      Y      |        Y        |        N           |      Y       |    N    |      Y     |
+    | netcoreapp2.0     |   Y   |    N     |         N           |      N      |        N        |        N           |      Y       |    N    |      Y     |
+    | netstandard2.1    |   Y   |    Y     |         N           |      Y      |        Y        |        N           |      Y       |    N    |      Y     |
+    | netstandard2.0    |   N   |    N     |         N           |      N      |        N        |        N           |      Y       |    N    |      N     |
+    | netstandard1.3    |   N   |    N     |         N           |      N      |        N        |        N           |      N       |    N    |      N     |
+    | net472            |   N   |    N     |         Y           |      N      |        N        |        N           |      Y       |    N    |      N     |
+    +===================+=======+==========+=====================+=============+=================+====================+==============+=========|============|
     -->
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_HASHCODE;SUPPORTS_EXTENDED_INTRINSICS;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING;SUPPORTS_RUNTIME_INTRINSICS;SUPPORTS_CODECOVERAGE;SUPPORTS_HOTPATH</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_HASHCODE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_SPAN_STREAM</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_ENCODING_STRING</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_RUNTIME_INTRINSICS</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_HOTPATH</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_CREATESPAN</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_HASHCODE;SUPPORTS_EXTENDED_INTRINSICS;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING;SUPPORTS_CODECOVERAGE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_HASHCODE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_SPAN_STREAM</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_ENCODING_STRING</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_CREATESPAN</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_CODECOVERAGE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_CREATESPAN</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF;SUPPORTS_HASHCODE;SUPPORTS_SPAN_STREAM;SUPPORTS_ENCODING_STRING;SUPPORTS_CODECOVERAGE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_HASHCODE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_SPAN_STREAM</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_ENCODING_STRING</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_CREATESPAN</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS;SUPPORTS_CODECOVERAGE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
+    <!--dotnet tools does not have an x86 runner. You have to use separate SDKs-->
+    <!--https://github.com/actions/setup-dotnet/issues/72-->
+    <DotNetCliToolReference Update="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <!--Don't update the SDK. It causes xunit to break for netcore 2.0-->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp2.0' ">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="1.3.0" PrivateAssets="All"/>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -52,10 +88,8 @@
     <PackageReference Include="System.Buffers" Version="4.5.0" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
-
-    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 

--- a/tests/SharedInfrastructure.Tests/SharedInfrastructure.Tests.csproj
+++ b/tests/SharedInfrastructure.Tests/SharedInfrastructure.Tests.csproj
@@ -67,7 +67,7 @@
   <ItemGroup>
     <!--dotnet tools does not have an x86 runner. You have to use separate SDKs-->
     <!--https://github.com/actions/setup-dotnet/issues/72-->
-    <DotNetCliToolReference Update="dotnet-xunit" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">

--- a/tests/coverlet.runsettings
+++ b/tests/coverlet.runsettings
@@ -5,8 +5,8 @@
             <DataCollector friendlyName="XPlat code coverage">
                 <Configuration>
                     <Format>lcov</Format>
-                    <Include>[SixLabors.*]*</Include>
-                    <UseSourceLink>false</UseSourceLink>
+                    <ExcludeByFile>**/tests/**/*.cs, **/**/*.Program.cs</ExcludeByFile>
+                    <IncludeTestAssembly>true</IncludeTestAssembly>
                 </Configuration>
             </DataCollector>
         </DataCollectors>

--- a/tests/coverlet.runsettings
+++ b/tests/coverlet.runsettings
@@ -5,8 +5,8 @@
             <DataCollector friendlyName="XPlat code coverage">
                 <Configuration>
                     <Format>lcov</Format>
-                    <Include>[SixLabors.*]*,[System.*]*</Include>
-                    <UseSourceLink>true</UseSourceLink>
+                    <Include>[SixLabors.*]*</Include>
+                    <UseSourceLink>false</UseSourceLink>
                 </Configuration>
             </DataCollector>
         </DataCollectors>

--- a/tests/coverlet.runsettings
+++ b/tests/coverlet.runsettings
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+    <DataCollectionRunSettings>
+        <DataCollectors>
+            <DataCollector friendlyName="XPlat code coverage">
+                <Configuration>
+                    <Format>lcov</Format>
+                    <Include>[SixLabors.*]*,[System.*]*</Include>
+                    <UseSourceLink>true</UseSourceLink>
+                </Configuration>
+            </DataCollector>
+        </DataCollectors>
+    </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
The JIT assumes that forward branches are always taken, and with the custom `ThrowHelper` methods used in the `Guard` APIs having the `[MethodImpl]` attributes, it couldn't see that they were always throwing, so the resulting codegen was not optimal. I've inverted all the conditions so that the forward branch is the likely one (the one that doesn't fault). This allowes the JIT to properly optimize the codegen in methods using the `Guard` APIs, eg. by only using jumps for the faulting paths and placing them further down in the code, with the likely branch not having to jump instead. These are the same changes done in the `Microsoft.Toolkit.Diagnostics.Guard` class, see https://github.com/windows-toolkit/WindowsCommunityToolkit/pull/3323.

**NOTE:** @JimBobSquarePants not sure how to generate that `.tt.bak` file, could you tell me what steps I should do here?