### PR TITLE
Add Shared Props and Targets

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,373 +1,436 @@
-###############################################################################
-# EditorConfig is awesome: http://EditorConfig.org
-###############################################################################
+# Version: 1.6.2 (Using https://semver.org/)
+# Updated: 2020-11-02
+# See https://github.com/RehanSaeed/EditorConfig/releases for release notes.
+# See https://github.com/RehanSaeed/EditorConfig for updates to this file.
+# See http://EditorConfig.org for more information about .editorconfig files.
 
-###############################################################################
-# Top-most EditorConfig file
-###############################################################################
+##########################################
+# Common Settings
+##########################################
+
+# This file is the top-most EditorConfig file
 root = true
 
-###############################################################################
-# Set default behavior to:
-#   a UTF-8 encoding,
-#   Unix-style line endings,
-#   a newline ending the file,
-#   4 space indentation, and
-#   trimming of trailing whitespace
-###############################################################################
+# All Files
 [*]
 charset = utf-8
-end_of_line = lf
-insert_final_newline = true
 indent_style = space
 indent_size = 4
+end_of_line = lf
+insert_final_newline = true
 trim_trailing_whitespace = true
 
-###############################################################################
-# Set file behavior to:
-#   2 space indentation
-###############################################################################
-[*.{cmd,config,csproj,json,props,ps1,resx,sh,targets}]
-indent_size = 2
+##########################################
+# File Extension Settings
+##########################################
 
-###############################################################################
-# Set file behavior to:
-#   Windows-style line endings, and
-#   tabular indentation
-###############################################################################
+# Visual Studio Solution Files
 [*.sln]
-end_of_line = crlf
 indent_style = tab
 
-###############################################################################
-# Set dotnet naming rules to:
-#    suggest async members be pascal case suffixed with Async
-#    suggest const declarations be pascal case
-#    suggest interfaces be pascal case prefixed with I
-#    suggest parameters be camel case
-#    suggest private and internal static fields be camel case
-#    suggest private and internal fields be camel case
-#    suggest public and protected declarations be pascal case
-#    suggest static readonly declarations be pascal case
-#    suggest type parameters be prefixed with T
-###############################################################################
-[*.cs]
-dotnet_naming_rule.async_members_should_be_pascal_case_suffixed_with_async.severity = suggestion
-dotnet_naming_rule.async_members_should_be_pascal_case_suffixed_with_async.style = pascal_case_suffixed_with_async
-dotnet_naming_rule.async_members_should_be_pascal_case_suffixed_with_async.symbols = async_members
+# Visual Studio XML Project Files
+[*.{csproj,vbproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
 
-dotnet_naming_rule.const_declarations_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.const_declarations_should_be_pascal_case.style = pascal_case
-dotnet_naming_rule.const_declarations_should_be_pascal_case.symbols = const_declarations
+# T4 Templates Files
+[*.{tt,ttinclude}]
+end_of_line = crlf
 
-dotnet_naming_rule.interfaces_should_be_pascal_case_prefixed_with_i.severity = suggestion
-dotnet_naming_rule.interfaces_should_be_pascal_case_prefixed_with_i.style = pascal_case_prefixed_with_i
-dotnet_naming_rule.interfaces_should_be_pascal_case_prefixed_with_i.symbols = interfaces
+# XML Configuration Files
+[*.{xml,config,props,targets,nuspec,resx,ruleset,vsixmanifest,vsct}]
+indent_size = 2
 
-dotnet_naming_rule.parameters_should_be_camel_case.severity = suggestion
-dotnet_naming_rule.parameters_should_be_camel_case.style = camel_case
-dotnet_naming_rule.parameters_should_be_camel_case.symbols = parameters
+# JSON Files
+[*.{json,json5,webmanifest}]
+indent_size = 2
 
-dotnet_naming_rule.private_and_internal_static_fields_should_be_camel_case.severity = suggestion
-dotnet_naming_rule.private_and_internal_static_fields_should_be_camel_case.style = camel_case
-dotnet_naming_rule.private_and_internal_static_fields_should_be_camel_case.symbols = private_and_internal_static_fields
+# YAML Files
+[*.{yml,yaml}]
+indent_size = 2
 
-dotnet_naming_rule.private_and_internal_fields_should_be_camel_case.severity = suggestion
-dotnet_naming_rule.private_and_internal_fields_should_be_camel_case.style = camel_case
-dotnet_naming_rule.private_and_internal_fields_should_be_camel_case.symbols = private_and_internal_fields
+# Markdown Files
+[*.md]
+trim_trailing_whitespace = false
 
-dotnet_naming_rule.public_and_protected_declarations_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.public_and_protected_declarations_should_be_pascal_case.style = pascal_case
-dotnet_naming_rule.public_and_protected_declarations_should_be_pascal_case.symbols = public_and_protected_declarations
-dotnet_naming_symbols.public_and_protected_declarations.applicable_kinds = method, field, event, property
+# Web Files
+[*.{htm,html,js,jsm,ts,tsx,css,sass,scss,less,svg,vue}]
+indent_size = 2
 
-dotnet_naming_rule.static_readonly_declarations_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.static_readonly_declarations_should_be_pascal_case.style = pascal_case
-dotnet_naming_rule.static_readonly_declarations_should_be_pascal_case.symbols = static_readonly_declarations
+# Batch Files
+[*.{cmd,bat}]
+end_of_line = crlf
 
-dotnet_naming_rule.type_parameters_should_be_pascal_case_prefixed_with_t.severity = suggestion
-dotnet_naming_rule.type_parameters_should_be_pascal_case_prefixed_with_t.style = pascal_case_prefixed_with_t
-dotnet_naming_rule.type_parameters_should_be_pascal_case_prefixed_with_t.symbols = type_parameters
+# Makefiles
+[Makefile]
+indent_style = tab
 
-###############################################################################
-# Set dotnet naming styles to define:
-#   camel case
-#   pascal case
-#   pascal case suffixed with Async
-#   pascal case prefixed with I
-#   pascal case prefixed with T
-###############################################################################
-[*.cs]
-dotnet_naming_style.camel_case.capitalization = camel_case
+##########################################
+# File Header (Uncomment to support file headers)
+# https://docs.microsoft.com/visualstudio/ide/reference/add-file-header
+##########################################
 
-dotnet_naming_style.pascal_case.capitalization = pascal_case
+# [*.{cs,csx,cake,vb,vbx,tt,ttinclude}]
+file_header_template = Copyright (c) Six Labors.\nLicensed under the Apache License, Version 2.0.
 
-dotnet_naming_style.pascal_case_suffixed_with_async.capitalization = pascal_case
-dotnet_naming_style.pascal_case_suffixed_with_async.required_suffix = Async
+# SA1636: File header copyright text should match
+# Justification: .editorconfig supports file headers. If this is changed to a value other than "none", a stylecop.json file will need to added to the project.
+# dotnet_diagnostic.SA1636.severity = none
 
-dotnet_naming_style.pascal_case_prefixed_with_i.capitalization = pascal_case
-dotnet_naming_style.pascal_case_prefixed_with_i.required_prefix = I
+##########################################
+# .NET Language Conventions
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions
+##########################################
 
-dotnet_naming_style.pascal_case_prefixed_with_t.capitalization = pascal_case
-dotnet_naming_style.pascal_case_prefixed_with_t.required_prefix = T
-
-###############################################################################
-# Set dotnet naming symbols to:
-#   async members
-#   const declarations
-#   interfaces
-#   private and internal fields
-#   private and internal static fields
-#   public and protected declarations
-#   static readonly declarations
-#   type parameters
-###############################################################################
-[*.cs]
-dotnet_naming_symbols.async_members.required_modifiers = async
-
-dotnet_naming_symbols.const_declarations.required_modifiers = const
-
-dotnet_naming_symbols.interfaces.applicable_kinds = interface
-
-dotnet_naming_symbols.parameters.applicable_kinds = parameter
-
-dotnet_naming_symbols.private_and_internal_fields.applicable_accessibilities = private, internal
-dotnet_naming_symbols.private_and_internal_fields.applicable_kinds = field
-
-dotnet_naming_symbols.private_and_internal_static_fields.applicable_accessibilities = private, internal
-dotnet_naming_symbols.private_and_internal_static_fields.applicable_kinds = field
-dotnet_naming_symbols.private_and_internal_static_fields.required_modifiers = static
-
-dotnet_naming_symbols.public_and_protected_declarations.applicable_accessibilities = public, protected
-
-dotnet_naming_symbols.static_readonly_declarations.required_modifiers = static, readonly
-
-dotnet_naming_symbols.type_parameters.applicable_kinds = type_parameter
-
-###############################################################################
-# Set dotnet sort options to:
-#   do not separate import directives into groups, and
-#   sort system directives first
-###############################################################################
-[*.cs]
-dotnet_separate_import_directive_groups = false
-dotnet_sort_system_directives_first = true
-
-###############################################################################
-# Set dotnet style options to:
-#   suggest null-coalescing expressions,
-#   suggest collection-initializers,
-#   suggest explicit tuple names,
-#   suggest null-propogation
-#   suggest object-initializers,
-#   generate parentheses in arithmetic binary operators for clarity,
-#   generate parentheses in other binary operators for clarity,
-#   don't generate parentheses in other operators if unnecessary,
-#   generate parentheses in relational binary operators for clarity,
-#   warn when not using predefined-types for locals, parameters, and members,
-#   generate predefined-types of type names for member access,
-#   generate auto properties,
-#   suggest compound assignment,
-#   generate conditional expression over assignment,
-#   generate conditional expression over return,
-#   suggest inferred anonymous types,
-#   suggest inferred tuple names,
-#   suggest 'is null' checks over '== null',
-#   don't generate 'this.' and 'Me.' for events,
-#   warn when not using 'this.' and 'Me.' for fields,
-#   warn when not using 'this.' and 'Me.' for methods,
-#   warn when not using 'this.' and 'Me.' for properties,
-#   suggest readonly fields, and
-#   generate accessibility modifiers for non interface members
-###############################################################################
-[*.cs]
-dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_collection_initializer = true:suggestion
-dotnet_style_explicit_tuple_names = true:suggestion
-dotnet_style_null_propagation = true:suggestion
-dotnet_style_object_initializer = true:suggestion
-
-dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
-dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
-dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
-dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
-
-dotnet_style_predefined_type_for_locals_parameters_members = true:warning
-dotnet_style_predefined_type_for_member_access = true:silent
-
-dotnet_style_prefer_auto_properties = true:silent
-dotnet_style_prefer_compound_assignment = true:suggestion
-dotnet_style_prefer_conditional_expression_over_assignment = true:silent
-dotnet_style_prefer_conditional_expression_over_return = true:silent
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-
-dotnet_style_qualification_for_event = false:silent
+# .NET Code Style Settings
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#net-code-style-settings
+[*.{cs,csx,cake,vb,vbx}]
+# "this." and "Me." qualifiers
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#this-and-me
 dotnet_style_qualification_for_field = true:warning
-dotnet_style_qualification_for_method = true:warning
 dotnet_style_qualification_for_property = true:warning
+dotnet_style_qualification_for_method = true:warning
+dotnet_style_qualification_for_event = true:warning
+# Language keywords instead of framework type names for type references
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#language-keywords
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
+# Modifier preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#normalize-modifiers
+dotnet_style_require_accessibility_modifiers = always:warning
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:warning
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:warning
+dotnet_style_readonly_field = true:warning
+# Parentheses preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#parentheses-preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:suggestion
+# Expression-level preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#expression-level-preferences
+dotnet_style_object_initializer = true:warning
+dotnet_style_collection_initializer = true:warning
+dotnet_style_explicit_tuple_names = true:warning
+dotnet_style_prefer_inferred_tuple_names = true:warning
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning
+dotnet_style_prefer_auto_properties = true:warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+dotnet_style_prefer_conditional_expression_over_assignment = false:suggestion
+dotnet_style_prefer_conditional_expression_over_return = false:suggestion
+dotnet_style_prefer_compound_assignment = true:warning
+# Null-checking preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#null-checking-preferences
+dotnet_style_coalesce_expression = true:warning
+dotnet_style_null_propagation = true:warning
+# Parameter preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#parameter-preferences
+dotnet_code_quality_unused_parameters = all:warning
+# More style options (Undocumented)
+# https://github.com/MicrosoftDocs/visualstudio-docs/issues/3641
+dotnet_style_operator_placement_when_wrapping = end_of_line
+# https://github.com/dotnet/roslyn/pull/40070
+dotnet_style_prefer_simplified_interpolation = true:warning
 
-dotnet_style_readonly_field = true:suggestion
-dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
-
-###############################################################################
-# Set dotnet style options to:
-#   suggest removing all unused parameters
-###############################################################################
-[*.cs]
-dotnet_code_quality_unused_parameters = all:suggestion
-
-###############################################################################
-# Set csharp indent options to:
-#   indent block contents,
-#   not indent braces,
-#   indent case contents,
-#   not indent case contents when block,
-#   indent labels one less than the current, and
-#   indent switch labels
-###############################################################################
-[*.cs]
-csharp_indent_block_contents = true
-csharp_indent_braces = false
-csharp_indent_case_contents = true
-csharp_indent_case_contents_when_block = false
-csharp_indent_labels = one_less_than_current
-csharp_indent_switch_labels = true
-
-###############################################################################
-# Set csharp new-line options to:
-#   insert a new-line before "catch",
-#   insert a new-line before "else",
-#   insert a new-line before "finally",
-#   insert a new-line before members in anonymous-types,
-#   insert a new-line before members in object-initializers, and
-#   insert a new-line before all open braces
-###############################################################################
-[*.cs]
-csharp_new_line_before_catch = true
-csharp_new_line_before_else = true
-csharp_new_line_before_finally = true
-
-csharp_new_line_before_members_in_anonymous_types = true
-csharp_new_line_before_members_in_object_initializers = true
-
-csharp_new_line_before_open_brace = all
-
-###############################################################################
-# Set csharp preserve options to:
-#   preserve single-line blocks, and
-#   preserve single-line statements
-###############################################################################
-[*.cs]
-csharp_preserve_single_line_blocks = true
-csharp_preserve_single_line_statements = true
-
-###############################################################################
-# Set csharp space options to:
-#   remove any space after a cast,
-#   add a space after the colon in an inheritance clause,
-#   add a space after a comma,
-#   remove any space after a dot,
-#   add a space after keywords in control flow statements,
-#   add a space after a semicolon in a "for" statement,
-#   add a space before and after binary operators,
-#   remove space around declaration statements,
-#   add a space before the colon in an inheritance clause,
-#   remove any space before a comma,
-#   remove any space before a dot,
-#   remove any space before an open square-bracket,
-#   remove any space before a semicolon in a "for" statement,
-#   remove any space between empty square-brackets,
-#   remove any space between a method call's empty parameter list parenthesis,
-#   remove any space between a method call's name and its opening parenthesis,
-#   remove any space between a method call's parameter list parenthesis,
-#   remove any space between a method declaration's empty parameter list parenthesis,
-#   remove any space between a method declaration's name and its openening parenthesis,
-#   remove any space between a method declaration's parameter list parenthesis,
-#   remove any space between parentheses, and
-#   remove any space between square brackets
-###############################################################################
-[*.cs]
-csharp_space_after_cast = false
-csharp_space_after_colon_in_inheritance_clause = true
-csharp_space_after_comma = true
-csharp_space_after_dot = false
-csharp_space_after_keywords_in_control_flow_statements = true
-csharp_space_after_semicolon_in_for_statement = true
-
-csharp_space_around_binary_operators = before_and_after
-csharp_space_around_declaration_statements = do_not_ignore
-
-csharp_space_before_colon_in_inheritance_clause = true
-csharp_space_before_comma = false
-csharp_space_before_dot = false
-csharp_space_before_open_square_brackets = false
-csharp_space_before_semicolon_in_for_statement = false
-
-csharp_space_between_empty_square_brackets = false
-csharp_space_between_method_call_empty_parameter_list_parentheses = false
-csharp_space_between_method_call_name_and_opening_parenthesis = false
-csharp_space_between_method_call_parameter_list_parentheses = false
-csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
-csharp_space_between_method_declaration_name_and_open_parenthesis = false
-csharp_space_between_method_declaration_parameter_list_parentheses = false
-csharp_space_between_parentheses = false
-csharp_space_between_square_brackets = false
-
-###############################################################################
-# Set csharp style options to:
-#   generate braces,
-#   suggest simple default expressions,
-#   generate a preferred modifier order,
-#   suggest conditional delegate calls,
-#   suggest deconstructed variable declarations,
-#   generate expression-bodied accessors,
-#   generate expression-bodied constructors,
-#   generate expression-bodied indexers,
-#   generate expression-bodied lambdas,
-#   generate expression-bodied methods,
-#   generate expression-bodied operators,
-#   generate expression-bodied properties,
-#   suggest inlined variable declarations,
-#   suggest local over anonymous functions,
-#   suggest pattern-matching over "as" with "null" check,
-#   suggest pattern-matching over "is" with "cast" check,
-#   suggest throw expressions,
-#   generate a discard variable for unused value expression statements,
-#   suggest a discard variable for unused assignments,
-#   warn when using var for built-in types,
-#   warn when using var when the type is not apparent, and
-#   warn when not using var when the type is apparent
-#   warn when using simplified "using" declaration
-###############################################################################
-[*.cs]
-csharp_prefer_braces = true:silent
-csharp_prefer_simple_default_expression = true:suggestion
-csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:silent
-
-csharp_style_conditional_delegate_call = true:suggestion
-csharp_style_deconstructed_variable_declaration = true:suggestion
-
-csharp_style_expression_bodied_accessors = true:silent
-csharp_style_expression_bodied_constructors = true:silent
-csharp_style_expression_bodied_indexers = true:silent
-csharp_style_expression_bodied_lambdas = true:silent
-csharp_style_expression_bodied_methods = true:silent
-csharp_style_expression_bodied_operators = true:silent
-csharp_style_expression_bodied_properties = true:silent
-
-csharp_style_inlined_variable_declaration = true:suggestion
-
-csharp_style_pattern_local_over_anonymous_function = true:suggestion
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-
-csharp_style_throw_expression = true:suggestion
-
-csharp_style_unused_value_expression_statement_preference = discard_variable:silent
-csharp_style_unused_value_assignment_preference = discard_variable:suggestion
-
+# C# Code Style Settings
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#c-code-style-settings
+[*.{cs,csx,cake}]
+# Implicit and explicit types
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#implicit-and-explicit-types
 csharp_style_var_for_built_in_types = never
 csharp_style_var_when_type_is_apparent = true:warning
 csharp_style_var_elsewhere = false:warning
+# Expression-bodied members
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#expression-bodied-members
+csharp_style_expression_bodied_methods = true:warning
+csharp_style_expression_bodied_constructors = true:warning
+csharp_style_expression_bodied_operators = true:warning
+csharp_style_expression_bodied_properties = true:warning
+csharp_style_expression_bodied_indexers = true:warning
+csharp_style_expression_bodied_accessors = true:warning
+csharp_style_expression_bodied_lambdas = true:warning
+csharp_style_expression_bodied_local_functions = true:warning
+# Pattern matching
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#pattern-matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+# Inlined variable declarations
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#inlined-variable-declarations
+csharp_style_inlined_variable_declaration = true:warning
+# Expression-level preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#expression-level-preferences
+csharp_prefer_simple_default_expression = true:warning
+# "Null" checking preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#c-null-checking-preferences
+csharp_style_throw_expression = true:warning
+csharp_style_conditional_delegate_call = true:warning
+# Code block preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#code-block-preferences
+csharp_prefer_braces = true:warning
+# Unused value preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#unused-value-preferences
+csharp_style_unused_value_expression_statement_preference = discard_variable:suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+# Index and range preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#index-and-range-preferences
+csharp_style_prefer_index_operator = true:warning
+csharp_style_prefer_range_operator = true:warning
+# Miscellaneous preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#miscellaneous-preferences
+csharp_style_deconstructed_variable_declaration = true:warning
+csharp_style_pattern_local_over_anonymous_function = true:warning
+csharp_using_directive_placement = outside_namespace:warning
+csharp_prefer_static_local_function = true:warning
+csharp_prefer_simple_using_statement = true:suggestion
+
+##########################################
+# .NET Formatting Conventions
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-code-style-settings-reference#formatting-conventions
+##########################################
+
+# Organize usings
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-formatting-conventions#organize-using-directives
+dotnet_sort_system_directives_first = true
+# Newline options
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-formatting-conventions#new-line-options
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+# Indentation options
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-formatting-conventions#indentation-options
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = no_change
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents_when_block = false
+# Spacing options
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-formatting-conventions#spacing-options
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_after_comma = true
+csharp_space_before_comma = false
+csharp_space_after_dot = false
+csharp_space_before_dot = false
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_around_declaration_statements = false
+csharp_space_before_open_square_brackets = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_square_brackets = false
+# Wrapping options
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-formatting-conventions#wrap-options
+csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_blocks = true
+
+##########################################
+# .NET Naming Conventions
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-naming-conventions
+##########################################
+
+[*.{cs,csx,cake,vb,vbx}]
+
+##########################################
+# Styles
+##########################################
+
+# camel_case_style - Define the camelCase style
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+# pascal_case_style - Define the PascalCase style
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+# first_upper_style - The first character must start with an upper-case character
+dotnet_naming_style.first_upper_style.capitalization = first_word_upper
+# prefix_interface_with_i_style - Interfaces must be PascalCase and the first character of an interface must be an 'I'
+dotnet_naming_style.prefix_interface_with_i_style.capitalization = pascal_case
+dotnet_naming_style.prefix_interface_with_i_style.required_prefix = I
+# prefix_type_parameters_with_t_style - Generic Type Parameters must be PascalCase and the first character must be a 'T'
+dotnet_naming_style.prefix_type_parameters_with_t_style.capitalization = pascal_case
+dotnet_naming_style.prefix_type_parameters_with_t_style.required_prefix = T
+# disallowed_style - Anything that has this style applied is marked as disallowed
+dotnet_naming_style.disallowed_style.capitalization  = pascal_case
+dotnet_naming_style.disallowed_style.required_prefix = ____RULE_VIOLATION____
+dotnet_naming_style.disallowed_style.required_suffix = ____RULE_VIOLATION____
+# internal_error_style - This style should never occur... if it does, it indicates a bug in file or in the parser using the file
+dotnet_naming_style.internal_error_style.capitalization  = pascal_case
+dotnet_naming_style.internal_error_style.required_prefix = ____INTERNAL_ERROR____
+dotnet_naming_style.internal_error_style.required_suffix = ____INTERNAL_ERROR____
+
+##########################################
+# .NET Design Guideline Field Naming Rules
+# Naming rules for fields follow the .NET Framework design guidelines
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/index
+##########################################
+
+# All public/protected/protected_internal constant fields must be PascalCase
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/field
+dotnet_naming_symbols.public_protected_constant_fields_group.applicable_accessibilities = public, protected, protected_internal
+dotnet_naming_symbols.public_protected_constant_fields_group.required_modifiers         = const
+dotnet_naming_symbols.public_protected_constant_fields_group.applicable_kinds           = field
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.symbols    = public_protected_constant_fields_group
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.style      = pascal_case_style
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.severity   = warning
+
+# All public/protected/protected_internal static readonly fields must be PascalCase
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/field
+dotnet_naming_symbols.public_protected_static_readonly_fields_group.applicable_accessibilities = public, protected, protected_internal
+dotnet_naming_symbols.public_protected_static_readonly_fields_group.required_modifiers         = static, readonly
+dotnet_naming_symbols.public_protected_static_readonly_fields_group.applicable_kinds           = field
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.symbols    = public_protected_static_readonly_fields_group
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.style      = pascal_case_style
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.severity   = warning
+
+# No other public/protected/protected_internal fields are allowed
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/field
+dotnet_naming_symbols.other_public_protected_fields_group.applicable_accessibilities = public, protected, protected_internal
+dotnet_naming_symbols.other_public_protected_fields_group.applicable_kinds           = field
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.symbols             = other_public_protected_fields_group
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.style               = disallowed_style
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.severity            = error
+
+##########################################
+# StyleCop Field Naming Rules
+# Naming rules for fields follow the StyleCop analyzers
+# This does not override any rules using disallowed_style above
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers
+##########################################
+
+# All constant fields must be PascalCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md
+dotnet_naming_symbols.stylecop_constant_fields_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected, private
+dotnet_naming_symbols.stylecop_constant_fields_group.required_modifiers         = const
+dotnet_naming_symbols.stylecop_constant_fields_group.applicable_kinds           = field
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.symbols    = stylecop_constant_fields_group
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.style      = pascal_case_style
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.severity   = warning
+
+# All static readonly fields must be PascalCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md
+dotnet_naming_symbols.stylecop_static_readonly_fields_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected, private
+dotnet_naming_symbols.stylecop_static_readonly_fields_group.required_modifiers         = static, readonly
+dotnet_naming_symbols.stylecop_static_readonly_fields_group.applicable_kinds           = field
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.symbols    = stylecop_static_readonly_fields_group
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.style      = pascal_case_style
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.severity   = warning
+
+# No non-private instance fields are allowed
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md
+dotnet_naming_symbols.stylecop_fields_must_be_private_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected
+dotnet_naming_symbols.stylecop_fields_must_be_private_group.applicable_kinds           = field
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.symbols               = stylecop_fields_must_be_private_group
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.style                 = disallowed_style
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.severity              = error
+
+# Private fields must be camelCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md
+dotnet_naming_symbols.stylecop_private_fields_group.applicable_accessibilities = private
+dotnet_naming_symbols.stylecop_private_fields_group.applicable_kinds           = field
+dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.symbols     = stylecop_private_fields_group
+dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.style       = camel_case_style
+dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.severity    = warning
+
+# Local variables must be camelCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1312.md
+dotnet_naming_symbols.stylecop_local_fields_group.applicable_accessibilities = local
+dotnet_naming_symbols.stylecop_local_fields_group.applicable_kinds           = local
+dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.symbols     = stylecop_local_fields_group
+dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.style       = camel_case_style
+dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.severity    = silent
+
+# This rule should never fire.  However, it's included for at least two purposes:
+# First, it helps to understand, reason about, and root-case certain types of issues, such as bugs in .editorconfig parsers.
+# Second, it helps to raise immediate awareness if a new field type is added (as occurred recently in C#).
+dotnet_naming_symbols.sanity_check_uncovered_field_case_group.applicable_accessibilities = *
+dotnet_naming_symbols.sanity_check_uncovered_field_case_group.applicable_kinds           = field
+dotnet_naming_rule.sanity_check_uncovered_field_case_rule.symbols  = sanity_check_uncovered_field_case_group
+dotnet_naming_rule.sanity_check_uncovered_field_case_rule.style    = internal_error_style
+dotnet_naming_rule.sanity_check_uncovered_field_case_rule.severity = error
+
+
+##########################################
+# Other Naming Rules
+##########################################
+
+# All of the following must be PascalCase:
+# - Namespaces
+#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-namespaces
+#   https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+# - Classes and Enumerations
+#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
+#   https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+# - Delegates
+#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces#names-of-common-types
+# - Constructors, Properties, Events, Methods
+#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-type-members
+dotnet_naming_symbols.element_group.applicable_kinds = namespace, class, enum, struct, delegate, event, method, property
+dotnet_naming_rule.element_rule.symbols              = element_group
+dotnet_naming_rule.element_rule.style                = pascal_case_style
+dotnet_naming_rule.element_rule.severity             = warning
+
+# Interfaces use PascalCase and are prefixed with uppercase 'I'
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
+dotnet_naming_symbols.interface_group.applicable_kinds = interface
+dotnet_naming_rule.interface_rule.symbols              = interface_group
+dotnet_naming_rule.interface_rule.style                = prefix_interface_with_i_style
+dotnet_naming_rule.interface_rule.severity             = warning
+
+# Generics Type Parameters use PascalCase and are prefixed with uppercase 'T'
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
+dotnet_naming_symbols.type_parameter_group.applicable_kinds = type_parameter
+dotnet_naming_rule.type_parameter_rule.symbols              = type_parameter_group
+dotnet_naming_rule.type_parameter_rule.style                = prefix_type_parameters_with_t_style
+dotnet_naming_rule.type_parameter_rule.severity             = warning
+
+# Function parameters use camelCase
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/naming-parameters
+dotnet_naming_symbols.parameters_group.applicable_kinds = parameter
+dotnet_naming_rule.parameters_rule.symbols              = parameters_group
+dotnet_naming_rule.parameters_rule.style                = camel_case_style
+dotnet_naming_rule.parameters_rule.severity             = warning
+
+##########################################
+# License
+##########################################
+# The following applies as to the .editorconfig file ONLY, and is
+# included below for reference, per the requirements of the license
+# corresponding to this .editorconfig file.
+# See: https://github.com/RehanSaeed/EditorConfig
+#
+# MIT License
+#
+# Copyright (c) 2017-2019 Muhammad Rehan Saeed
+# Copyright (c) 2019 Henry Gabryjelski
+#
+# Permission is hereby granted, free of charge, to any
+# person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the
+# Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute,
+# sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject
+# to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+##########################################

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,6 +16,10 @@ jobs:
                       framework: netcoreapp3.1
                       runtime: -x64
                       codecov: false
+                    - os: macos-latest
+                      framework: netcoreapp3.1
+                      runtime: -x64
+                      codecov: false
                     - os: windows-latest
                       framework: netcoreapp3.1
                       runtime: -x64
@@ -61,6 +65,14 @@ jobs:
                   git config --global core.longpaths true
                   git fetch --prune --unshallow
                   git submodule -q update --init --recursive
+
+            - name: Setup NuGet Cache
+              uses: actions/cache@v2
+              id: nuget-cache
+              with:
+                  path: ~/.nuget
+                  key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets') }}
+                  restore-keys: ${{ runner.os }}-nuget-
 
             - name: Build
               shell: pwsh

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <!--
+    Directory.Build.props is automatically picked up and imported by
+    Microsoft.Common.props. This file needs to exist, even if empty so that
+    files in the parent directory tree, with the same name, are not imported
+    instead. They import fairly early and only Sdk.props will have been imported
+    beforehand. We also don't need to add ourselves to MSBuildAllProjects, as
+    that is done by the file that imports us.
+  -->
+
+  <PropertyGroup>
+    <!-- This MUST be defined before importing props. -->
+    <SixLaborsSolutionDirectory>$(MSBuildThisFileDirectory)</SixLaborsSolutionDirectory>
+  </PropertyGroup>
+
+  <!-- Import the shared global .props file -->
+  <Import Project="$(SixLaborsSolutionDirectory)msbuild\props\SixLabors.Global.props"/>
+
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <!--
+    Directory.Build.targets is automatically picked up and imported by
+    Microsoft.Common.targets. This file needs to exist, even if empty so that
+    files in the parent directory tree, with the same name, are not imported
+    instead. They import fairly late and most other props/targets will have been
+    imported beforehand. We also don't need to add ourselves to
+    MSBuildAllProjects, as that is done by the file that imports us.
+  -->
+
+  <!-- Import the global .targets file -->
+  <Import Project="$(SixLaborsSolutionDirectory)msbuild\targets\SixLabors.Global.targets"/>
+
+</Project>

--- a/SharedInfrastructure.sln
+++ b/SharedInfrastructure.sln
@@ -49,6 +49,22 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{478B60EE
 		tests\Directory.Build.targets = tests\Directory.Build.targets
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "msbuild", "msbuild", "{F8DA0585-5F98-48F6-9A68-5E26EDD3F1D4}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "props", "props", "{8EDAC650-9105-421F-8988-E3AE6EDF77F7}"
+	ProjectSection(SolutionItems) = preProject
+		msbuild\props\SixLabors.Global.props = msbuild\props\SixLabors.Global.props
+		msbuild\props\SixLabors.Src.props = msbuild\props\SixLabors.Src.props
+		msbuild\props\SixLabors.Tests.props = msbuild\props\SixLabors.Tests.props
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "targets", "targets", "{A4111E2B-C16C-4029-92D0-A9F367AE1B20}"
+	ProjectSection(SolutionItems) = preProject
+		msbuild\targets\SixLabors.Global.targets = msbuild\targets\SixLabors.Global.targets
+		msbuild\targets\SixLabors.Src.targets = msbuild\targets\SixLabors.Src.targets
+		msbuild\targets\SixLabors.Tests.targets = msbuild\targets\SixLabors.Tests.targets
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\SharedInfrastructure\SharedInfrastructure.projitems*{1664b46a-d99f-4c66-9424-a3a17c926a4c}*SharedItemsImports = 5
@@ -72,6 +88,9 @@ Global
 		{68A8CC40-6AED-4E96-B524-31B1158FDEEA} = {07706BC0-CA04-4558-A005-3F9FA7D9933C}
 		{91A98DCB-FA23-444B-865A-3734578F1C28} = {27502888-A75B-4BCB-8D19-C81198AEF7C7}
 		{B3C84CC9-D0F5-4D9F-93A8-D742A73F3674} = {91A98DCB-FA23-444B-865A-3734578F1C28}
+		{F8DA0585-5F98-48F6-9A68-5E26EDD3F1D4} = {27502888-A75B-4BCB-8D19-C81198AEF7C7}
+		{8EDAC650-9105-421F-8988-E3AE6EDF77F7} = {F8DA0585-5F98-48F6-9A68-5E26EDD3F1D4}
+		{A4111E2B-C16C-4029-92D0-A9F367AE1B20} = {F8DA0585-5F98-48F6-9A68-5E26EDD3F1D4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CDD6BE8E-01A1-4A70-AA7E-F1D64E8FA829}

--- a/SharedInfrastructure.sln
+++ b/SharedInfrastructure.sln
@@ -15,6 +15,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_root", "_root", "{27502888
 		ci-build.ps1 = ci-build.ps1
 		ci-test.ps1 = ci-test.ps1
 		codecov.yml = codecov.yml
+		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
 		LICENSE = LICENSE
 		README.md = README.md
 		SixLabors.ruleset = SixLabors.ruleset
@@ -35,10 +37,16 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{07706BC0-CA04-4558-A005-3F9FA7D9933C}"
+	ProjectSection(SolutionItems) = preProject
+		src\Directory.Build.props = src\Directory.Build.props
+		src\Directory.Build.targets = src\Directory.Build.targets
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{478B60EE-3651-4B39-83BD-528C428AC628}"
 	ProjectSection(SolutionItems) = preProject
 		tests\coverlet.runsettings = tests\coverlet.runsettings
+		tests\Directory.Build.props = tests\Directory.Build.props
+		tests\Directory.Build.targets = tests\Directory.Build.targets
 	EndProjectSection
 EndProject
 Global

--- a/SixLabors.Tests.ruleset
+++ b/SixLabors.Tests.ruleset
@@ -1,57 +1,29 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="SixLabors.Tests" ToolsVersion="15.0">
-  <!--Inherit basic rules-->
+<RuleSet Name="SixLabors.Tests" ToolsVersion="16.0">
   <Include Path="SixLabors.ruleset" Action="Default" />
-
-  <!--Additional rules-->
-  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-
-    <!--XML comment analysis is disabled due to project configuration-->
-    <Rule Id="SA0001" Action="None" />
-
-    <!--Parameter must follow comma.-->
-    <Rule Id="SA1115" Action="None" />
-
-    <!--A field should not follow a method-->
-    <Rule Id="SA1201" Action="None" />
-
-    <!--Elements must be ordered by access-->
-    <Rule Id="SA1202" Action="None" />
-
-    <!--Constants must appear before fields-->
-    <Rule Id="SA1203" Action="None" />
-
-    <!--Static members should appear before non-static members-->
-    <Rule Id="SA1204" Action="None" />
-
-    <!--Field names must not contain underscore-->
-    <Rule Id="SA1310" Action="None" />
-
-    <!--Field should be private-->
-    <Rule Id="SA1401" Action="None" />
-
-    <!--Elements should be documented.-->
-    <Rule Id="SA1600" Action="None" />
-
-    <!--Partial elements should be documented.-->
-    <Rule Id="SA1601" Action="None" />
-
-    <!--Enumeration items should be documented.-->
-    <Rule Id="SA1602" Action="None" />
-
-    <!--Constructor is missing documentation for one or more of its parameters.-->
-    <Rule Id="SA1611" Action="None" />
-
-    <!--A generic C# element is missing documentation for one or more of its generic type parameters..-->
-    <Rule Id="SA1618" Action="None" />
-
-    <!--The XML documentation header for a C# constructor does not contain the appropriate summary text.-->
-    <Rule Id="SA1642" Action="None" />
-  </Rules>
-
   <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
-
-      <!--Missing XML comment for publicly visible type or member-->
     <Rule Id="CS1591" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
+    <Rule Id="IDE0058" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.VisualBasic.Features" RuleNamespace="Microsoft.CodeAnalysis.VisualBasic.Features">
+    <Rule Id="IDE0058" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" />
+    <Rule Id="SA1115" Action="None" />
+    <Rule Id="SA1201" Action="None" />
+    <Rule Id="SA1202" Action="None" />
+    <Rule Id="SA1203" Action="None" />
+    <Rule Id="SA1204" Action="None" />
+    <Rule Id="SA1310" Action="None" />
+    <Rule Id="SA1401" Action="None" />
+    <Rule Id="SA1600" Action="None" />
+    <Rule Id="SA1601" Action="None" />
+    <Rule Id="SA1602" Action="None" />
+    <Rule Id="SA1611" Action="None" />
+    <Rule Id="SA1618" Action="None" />
+    <Rule Id="SA1642" Action="None" />
   </Rules>
 </RuleSet>

--- a/SixLabors.ruleset
+++ b/SixLabors.ruleset
@@ -1,26 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="SixLabors" ToolsVersion="15.0">
+<RuleSet Name="SixLabors" ToolsVersion="16.0">
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
+    <Rule Id="IDE0057" Action="None" />
+  </Rules>
   <Rules AnalyzerId="Roslynator.CSharp.Analyzers" RuleNamespace="Roslynator.CSharp">
-
-    <!--Call 'ConfigureAwait(false)'-->
     <Rule Id="RCS1090" Action="None" />
   </Rules>
-
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-
-    <!--Using directive should appear within a namespace declaration-->
     <Rule Id="SA1200" Action="None" />
-
-    <!--A C# code file contains more than one unique type.-->
     <Rule Id="SA1402" Action="None" />
-
-    <!--The last statement in a multi-line C# initializer or list is missing a trailing comma.-->
     <Rule Id="SA1413" Action="None" />
-
-    <!--Comments should end with a period. I like this but there's 2956+ errors to fix in ImageSharp-->
     <Rule Id="SA1629" Action="None" />
-
-    <!--A C# code file is missing a standard file header.-->
-    <Rule Id="SA1633" Action="Warning" />
   </Rules>
 </RuleSet>

--- a/msbuild/props/SixLabors.Global.props
+++ b/msbuild/props/SixLabors.Global.props
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <!--
+    Directory.Build.props is automatically picked up and imported by
+    Microsoft.Common.props. This file needs to exist, even if empty so that
+    files in the parent directory tree, with the same name, are not imported
+    instead. They import fairly early and only Sdk.props will have been imported
+    beforehand. We also don't need to add ourselves to MSBuildAllProjects, as
+    that is done by the file that imports us.
+  -->
+
+  <!-- Compilation settings that explicitly differ from the Sdk.props/targets defaults  -->
+  <PropertyGroup>
+    <LangVersion Condition="'$(LangVersion)' == ''">8.0</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Features>strict;IOperation</Features>
+    <HighEntropyVA>true</HighEntropyVA>
+    <NeutralLanguage>en</NeutralLanguage>
+    <OverwriteReadOnlyFiles>true</OverwriteReadOnlyFiles>
+    <DebugType>portable</DebugType>
+    <DebugType Condition="'$(codecov)' != ''">full</DebugType>
+    <NullableContextOptions>disable</NullableContextOptions>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+  </PropertyGroup>
+
+  <!-- Required restore feeds. -->
+  <PropertyGroup>
+    <RestoreSources>
+      $(RestoreSources);
+      https://api.nuget.org/v3/index.json;
+      https://www.myget.org/F/sixlabors/api/v3/index.json;
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json;
+      https://f.feedz.io/marcorossignoli/coverletunofficial/nuget/index.json;
+    </RestoreSources>
+  </PropertyGroup>
+
+  <!-- Standardize build output location. -->
+  <PropertyGroup>
+    <BaseArtifactsPath>$(SixLaborsSolutionDirectory)artifacts/</BaseArtifactsPath>
+    <BaseArtifactsPathSuffix>$(SixLaborsProjectCategory)/$(MSBuildProjectName)</BaseArtifactsPathSuffix>
+    <BaseIntermediateOutputPath>$(BaseArtifactsPath)obj/$(BaseArtifactsPathSuffix)/</BaseIntermediateOutputPath>
+    <BaseOutputPath>$(BaseArtifactsPath)bin/$(BaseArtifactsPathSuffix)/</BaseOutputPath>
+    <PackageOutputPath>$(BaseArtifactsPath)pkg/$(BaseArtifactsPathSuffix)/$(Configuration)/</PackageOutputPath>
+  </PropertyGroup>
+
+  <!-- Public key definition for signing assemblies. -->
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\..\SixLabors.snk</AssemblyOriginatorKeyFile>
+    <SixLaborsPublicKey>00240000048000009400000006020000002400005253413100040000010001000147e6fe6766715eec6cfed61f1e7dcdbf69748a3e355c67e9d8dfd953acab1d5e012ba34b23308166fdc61ee1d0390d5f36d814a6091dd4b5ed9eda5a26afced924c683b4bfb4b3d64b0586a57eff9f02b1f84e3cb0ddd518bd1697f2c84dcbb97eb8bb5c7801be12112ed0ec86db934b0e9a5171e6bb1384b6d2f7d54dfa97</SixLaborsPublicKey>
+    <UseSharedCompilation>true</UseSharedCompilation>
+  </PropertyGroup>
+
+  <!-- Package references and additional files which are consumed by all projects. -->
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" IsImplicitlyDefined="true"  />
+    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Version="1.1.118" IsImplicitlyDefined="true" />
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\..\stylecop.json" />
+  </ItemGroup>
+
+  <!--Define OS platform conditions and constants.
+   https://docs.microsoft.com/en-us/visualstudio/msbuild/property-functions?view=vs-2019#msbuild-property-functions
+   https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.osplatform?view=net-5.0#properties
+   -->
+  <PropertyGroup>
+    <IsWindows Condition="$([MSBuild]::IsOSPlatform('Windows'))">true</IsWindows>
+    <IsOSX Condition="$([MSBuild]::IsOSPlatform('OSX'))">true</IsOSX>
+    <IsLinux Condition="$([MSBuild]::IsOSPlatform('Linux'))">true</IsLinux>
+    <IsFreeBSD Condition="$([MSBuild]::IsOSPlatform('FreeBSD'))">true</IsFreeBSD>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(IsWindows)'=='true'">
+      <PropertyGroup>
+        <DefineConstants>$(DefineConstants);OS_WINDOWS</DefineConstants>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(IsOSX)'=='true'">
+      <PropertyGroup>
+        <DefineConstants>$(DefineConstants);OS_OSX</DefineConstants>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(IsLinux)'=='true'">
+      <PropertyGroup>
+        <DefineConstants>$(DefineConstants);OS_LINUX</DefineConstants>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(IsFreeBSD)'=='true'">
+      <PropertyGroup>
+        <DefineConstants>$(DefineConstants);OS_FREEBSD</DefineConstants>
+      </PropertyGroup>
+    </When>
+  </Choose>
+
+  <!-- Define target framework specific constants.
+    https://apisof.net/
+    +===================+=======+==========+=====================+=============+=================+====================+==============+=========+============|
+    | SUPPORTS          | MATHF | HASHCODE | EXTENDED_INTRINSICS | SPAN_STREAM | ENCODING_STRING | RUNTIME_INTRINSICS | CODECOVERAGE | HOTPATH | CREATESPAN |
+    +===================+=======+==========+=====================+=============+=================+====================+==============+=========|============|
+    | netcoreapp3.1     |   Y   |    Y     |         Y           |      Y      |        Y        |        Y           |      Y       |    Y    |      Y     |
+    | netcoreapp2.1     |   Y   |    Y     |         Y           |      Y      |        Y        |        N           |      Y       |    N    |      Y     |
+    | netcoreapp2.0     |   Y   |    N     |         N           |      N      |        N        |        N           |      Y       |    N    |      Y     |
+    | netstandard2.1    |   Y   |    Y     |         N           |      Y      |        Y        |        N           |      Y       |    N    |      Y     |
+    | netstandard2.0    |   N   |    N     |         N           |      N      |        N        |        N           |      Y       |    N    |      N     |
+    | netstandard1.3    |   N   |    N     |         N           |      N      |        N        |        N           |      N       |    N    |      N     |
+    | net472            |   N   |    N     |         Y           |      N      |        N        |        N           |      Y       |    N    |      N     |
+    +===================+=======+==========+=====================+=============+=================+====================+==============+=========|============|
+    -->
+  <Choose>
+    <When Condition="'$(TargetFramework)' == 'net472'">
+      <PropertyGroup>
+        <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS</DefineConstants>
+        <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(TargetFramework)' == 'netstandard2.0'">
+      <PropertyGroup>
+        <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS</DefineConstants>
+        <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(TargetFramework)' == 'netstandard2.1'">
+      <PropertyGroup>
+        <DefineConstants>$(DefineConstants);SUPPORTS_MATHF</DefineConstants>
+        <DefineConstants>$(DefineConstants);SUPPORTS_HASHCODE</DefineConstants>
+        <DefineConstants>$(DefineConstants);SUPPORTS_SPAN_STREAM</DefineConstants>
+        <DefineConstants>$(DefineConstants);SUPPORTS_ENCODING_STRING</DefineConstants>
+        <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
+        <DefineConstants>$(DefineConstants);SUPPORTS_CREATESPAN</DefineConstants>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+      <PropertyGroup>
+        <DefineConstants>$(DefineConstants);SUPPORTS_MATHF</DefineConstants>
+        <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
+        <DefineConstants>$(DefineConstants);SUPPORTS_CREATESPAN</DefineConstants>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+      <PropertyGroup>
+        <DefineConstants>$(DefineConstants);SUPPORTS_MATHF</DefineConstants>
+        <DefineConstants>$(DefineConstants);SUPPORTS_HASHCODE</DefineConstants>
+        <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS</DefineConstants>
+        <DefineConstants>$(DefineConstants);SUPPORTS_SPAN_STREAM</DefineConstants>
+        <DefineConstants>$(DefineConstants);SUPPORTS_ENCODING_STRING</DefineConstants>
+        <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
+        <DefineConstants>$(DefineConstants);SUPPORTS_CREATESPAN</DefineConstants>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+      <!--NETCORE 3.1. NET5.0, and future versions will fallback to this as the closest target.-->
+      <PropertyGroup>
+        <DefineConstants>$(DefineConstants);SUPPORTS_MATHF</DefineConstants>
+        <DefineConstants>$(DefineConstants);SUPPORTS_HASHCODE</DefineConstants>
+        <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS</DefineConstants>
+        <DefineConstants>$(DefineConstants);SUPPORTS_SPAN_STREAM</DefineConstants>
+        <DefineConstants>$(DefineConstants);SUPPORTS_ENCODING_STRING</DefineConstants>
+        <DefineConstants>$(DefineConstants);SUPPORTS_RUNTIME_INTRINSICS</DefineConstants>
+        <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
+        <DefineConstants>$(DefineConstants);SUPPORTS_HOTPATH</DefineConstants>
+        <DefineConstants>$(DefineConstants);SUPPORTS_CREATESPAN</DefineConstants>
+      </PropertyGroup>
+    </When>
+  </Choose>
+
+</Project>

--- a/msbuild/props/SixLabors.Src.props
+++ b/msbuild/props/SixLabors.Src.props
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <!-- Compilation and build location settings. -->
+  <PropertyGroup>
+    <SixLaborsProjectCategory>src</SixLaborsProjectCategory>
+    <CodeAnalysisRuleSet Condition="'$(CodeAnalysisRuleSet)' == ''">$(MSBuildThisFileDirectory)..\..\SixLabors.ruleset</CodeAnalysisRuleSet>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!-- Add deterministic builds in CI .-->
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+
+  <!-- Common NuGet package settings. -->
+  <PropertyGroup>
+    <Copyright>Copyright © Six Labors</Copyright>
+    <Authors>Six Labors and contributors</Authors>
+    <Company>Six Labors</Company>
+    <VersionPrefix>0.0.1</VersionPrefix>
+    <VersionPrefix Condition="'$(packageversion)' != ''">$(PackageVersion)</VersionPrefix>
+    <VersionSuffix></VersionSuffix>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    <RepositoryType>git</RepositoryType>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <!-- Package references and additional files which are consumed by src projects -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" IsImplicitlyDefined="true" />
+    <PackageReference Include="MinVer" PrivateAssets="All" Version="2.3.1" IsImplicitlyDefined="true"/>
+  </ItemGroup>
+
+  <!--MinVer Properties for versioning-->
+  <PropertyGroup>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+    <MinVerVerbosity>normal</MinVerVerbosity>
+  </PropertyGroup>
+
+</Project>

--- a/msbuild/props/SixLabors.Tests.props
+++ b/msbuild/props/SixLabors.Tests.props
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <!-- Compilation and build location settings. -->
+  <PropertyGroup>
+    <SixLaborsProjectCategory>tests</SixLaborsProjectCategory>
+    <IsTestProject Condition="'$(IsTestProject)' == ''">true</IsTestProject>
+    <IsPackable>false</IsPackable>
+    <CodeAnalysisRuleSet Condition="'$(CodeAnalysisRuleSet)' == ''">$(MSBuildThisFileDirectory)..\..\SixLabors.Tests.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
+  <!-- Package references and additional files which are consumed by test projects -->
+  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
+    <!--
+      Setup-dotnet action does not have an x86 runner. You have to use separate SDKs
+      https://github.com/actions/setup-dotnet/issues/72
+    -->
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" IsImplicitlyDefined="true" />
+    <PackageReference Include="xunit" Version="2.4.1" IsImplicitlyDefined="true" />
+
+    <PackageReference Include="coverlet.collector"
+                      Version="3.0.0-preview.9"
+                      PrivateAssets="All"
+                      IsImplicitlyDefined="true"
+                      Condition="'$(codecov)' == 'true'"/>
+
+    <!-- Maximum compatible version for xunit with netcore 2.0 -->
+    <PackageReference Include="Microsoft.NET.Test.Sdk"
+                      Version="16.2.0"
+                      IsImplicitlyDefined="true"
+                      Condition="'$(TargetFramework)' == 'netcoreapp2.0'"/>
+
+    <PackageReference Include="Microsoft.NET.Test.Sdk"
+                      Version="16.8.0"
+                      IsImplicitlyDefined="true"
+                      Condition="'$(TargetFramework)' != 'netcoreapp2.0'"/>
+
+    <!-- Maximum compatible version with net46 or net472-->
+    <PackageReference Include="xunit.runner.visualstudio"
+                      Version="2.4.1"
+                      IsImplicitlyDefined="true"
+                      Condition="'$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'netcoreapp2.0'" />
+
+    <PackageReference Include="xunit.runner.visualstudio"
+                      Version="2.4.3"
+                      IsImplicitlyDefined="true"
+                      Condition="'$(TargetFramework)' != 'net46' AND '$(TargetFramework)' != 'net472' AND '$(TargetFramework)' != 'netcoreapp2.0'" />
+  </ItemGroup>
+
+</Project>

--- a/msbuild/targets/SixLabors.Global.targets
+++ b/msbuild/targets/SixLabors.Global.targets
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <!--
+    Directory.Build.targets is automatically picked up and imported by
+    Microsoft.Common.targets. This file needs to exist, even if empty so that
+    files in the parent directory tree, with the same name, are not imported
+    instead. They import fairly late and most other props/targets will have been
+    imported beforehand. We also don't need to add ourselves to
+    MSBuildAllProjects, as that is done by the file that imports us.
+  -->
+
+  <!--
+  Allow "InternalsVisibleTo" usage in src props file.
+  Usage:
+  <InternalsVisibleTo Include="[ASSEMBLY_NAME]" Key="$(SixLaborsPublicKey)" />
+  -->
+  <PropertyGroup>
+    <GeneratedInternalsVisibleToFile Condition="'$(GeneratedInternalsVisibleToFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).InternalsVisibleTo$(DefaultLanguageSourceExtension)</GeneratedInternalsVisibleToFile>
+  </PropertyGroup>
+
+  <ItemDefinitionGroup>
+    <InternalsVisibleTo>
+      <Visible>false</Visible>
+    </InternalsVisibleTo>
+  </ItemDefinitionGroup>
+
+  <Target Name="GenerateInternalsVisibleTo"
+          BeforeTargets="CoreCompile"
+          DependsOnTargets="PrepareForBuild;CoreGenerateInternalsVisibleTo"
+          Condition="'@(InternalsVisibleTo)' != ''" />
+
+  <Target Name="CoreGenerateInternalsVisibleTo"
+          Condition="'$(Language)' == 'VB' or '$(Language)' == 'C#'"
+          Inputs="$(MSBuildAllProjects)"
+          Outputs="$(GeneratedInternalsVisibleToFile)">
+    <CreateItem
+      Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute"
+      AdditionalMetadata="_Parameter1=%(InternalsVisibleTo.Identity)"
+      Condition="'%(InternalsVisibleTo.Key)' == ''">
+      <Output TaskParameter="Include" ItemName="InternalsVisibleToAttribute" />
+    </CreateItem>
+    <CreateItem
+      Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute"
+      AdditionalMetadata="_Parameter1=%(InternalsVisibleTo.Identity), PublicKey=%(InternalsVisibleTo.Key)"
+      Condition="'%(InternalsVisibleTo.Key)' != ''">
+      <Output TaskParameter="Include" ItemName="InternalsVisibleToAttribute" />
+    </CreateItem>
+
+    <WriteCodeFragment AssemblyAttributes="@(InternalsVisibleToAttribute)" Language="$(Language)" OutputFile="$(GeneratedInternalsVisibleToFile)">
+      <Output TaskParameter="OutputFile" ItemName="Compile" />
+      <Output TaskParameter="OutputFile" ItemName="FileWrites" />
+    </WriteCodeFragment>
+  </Target>
+
+</Project>

--- a/msbuild/targets/SixLabors.Src.targets
+++ b/msbuild/targets/SixLabors.Src.targets
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <!-- Empty target so that `dotnet test` will work on the solution -->
+  <!-- https://github.com/Microsoft/vstest/issues/411 -->
+  <Target Name="VSTest" Condition="'$(IsTestProject)' == 'true'"/>
+
+  <ItemGroup>
+    <!-- Shared config files that have to exist at root level. -->
+    <SixLaborsConfigFilesToCopy Include="$(MSBuildThisFileDirectory)..\..\.editorconfig;$(MSBuildThisFileDirectory)..\..\.gitattributes" />
+  </ItemGroup>
+
+  <!-- Copy the config files on src build. -->
+  <Target Name="SixLaborsCopyConfigFiles" BeforeTargets="Build" Condition="'$(SixLaborsDisableConfigCopy)' == ''">
+    <Copy SourceFiles="@(SixLaborsConfigFilesToCopy)"
+          SkipUnchangedFiles = "true"
+          DestinationFolder="$(SixLaborsSolutionDirectory)" />
+  </Target>
+
+</Project>

--- a/msbuild/targets/SixLabors.Tests.targets
+++ b/msbuild/targets/SixLabors.Tests.targets
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+    <!-- Empty for now. -->
+</Project>

--- a/msbuild/targets/SixLabors.Tests.targets
+++ b/msbuild/targets/SixLabors.Tests.targets
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-    <!-- Empty for now. -->
+  <!-- Empty for now. -->
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <!-- Import the shared src .props file -->
+  <Import Project="$(MSBuildThisFileDirectory)..\msbuild\props\SixLabors.Src.props"/>
+  
+  <!-- Import the solution .props file. -->
+  <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props"/>
+
+</Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <!-- Import the solution .targets file. -->
+  <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props"/>
+
+  <!-- Import the shared src .targets file -->
+  <Import Project="$(SixLaborsSolutionDirectory)msbuild\targets\SixLabors.Src.targets"/>
+
+</Project>

--- a/src/SharedInfrastructure/MathF.cs
+++ b/src/SharedInfrastructure/MathF.cs
@@ -32,9 +32,7 @@ namespace System
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Abs(float f)
-        {
-            return Math.Abs(f);
-        }
+            => Math.Abs(f);
 
         /// <summary>
         /// Returns the angle whose tangent is the quotient of two specified numbers.
@@ -54,9 +52,7 @@ namespace System
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Atan2(float y, float x)
-        {
-            return (float)Math.Atan2(y, x);
-        }
+            => (float)Math.Atan2(y, x);
 
         /// <summary>
         /// Returns the smallest integral value that is greater than or equal to the specified single-precision floating-point number.
@@ -70,9 +66,7 @@ namespace System
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Ceiling(float f)
-        {
-            return (float)Math.Ceiling(f);
-        }
+            => (float)Math.Ceiling(f);
 
         /// <summary>
         /// Returns the cosine of the specified angle.
@@ -84,9 +78,7 @@ namespace System
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Cos(float f)
-        {
-            return (float)Math.Cos(f);
-        }
+            => (float)Math.Cos(f);
 
         /// <summary>
         /// Returns e raised to the specified power.
@@ -99,9 +91,7 @@ namespace System
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Exp(float f)
-        {
-            return (float)Math.Exp(f);
-        }
+            => (float)Math.Exp(f);
 
         /// <summary>
         /// Returns the largest integer less than or equal to the specified single-precision floating-point number.
@@ -114,9 +104,7 @@ namespace System
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Floor(float f)
-        {
-            return (float)Math.Floor(f);
-        }
+            => (float)Math.Floor(f);
 
         /// <summary>
         /// Returns the larger of two single-precision floating-point numbers.
@@ -130,9 +118,7 @@ namespace System
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Max(float val1, float val2)
-        {
-            return Math.Max(val1, val2);
-        }
+            => Math.Max(val1, val2);
 
         /// <summary>
         /// Returns the smaller of two single-precision floating-point numbers.
@@ -146,9 +132,7 @@ namespace System
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Min(float val1, float val2)
-        {
-            return Math.Min(val1, val2);
-        }
+            => Math.Min(val1, val2);
 
         /// <summary>
         /// Returns a specified number raised to the specified power.
@@ -158,9 +142,7 @@ namespace System
         /// <returns>The number <paramref name="x" /> raised to the power <paramref name="y" />.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Pow(float x, float y)
-        {
-            return (float)Math.Pow(x, y);
-        }
+            => (float)Math.Pow(x, y);
 
         /// <summary>
         /// Rounds a single-precision floating-point value to the nearest integral value.
@@ -173,9 +155,7 @@ namespace System
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Round(float f)
-        {
-            return (float)Math.Round(f);
-        }
+            => (float)Math.Round(f);
 
         /// <summary>
         /// Rounds a single-precision floating-point value to the nearest integer.
@@ -192,9 +172,7 @@ namespace System
         /// <paramref name="mode" /> is not a valid value of <see cref="T:System.MidpointRounding" />.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Round(float f, MidpointRounding mode)
-        {
-            return (float)Math.Round(f, mode);
-        }
+            => (float)Math.Round(f, mode);
 
         /// <summary>
         /// Returns the sine of the specified angle.
@@ -207,9 +185,7 @@ namespace System
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Sin(float f)
-        {
-            return (float)Math.Sin(f);
-        }
+            => (float)Math.Sin(f);
 
         /// <summary>
         /// Returns the square root of a specified number.
@@ -224,9 +200,7 @@ namespace System
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Sqrt(float f)
-        {
-            return (float)Math.Sqrt(f);
-        }
+            => (float)Math.Sqrt(f);
     }
 }
 #endif

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <PropertyGroup>
+    <!--Disable config copy. This solution only.-->
+    <SixLaborsDisableConfigCopy>true</SixLaborsDisableConfigCopy>
+  </PropertyGroup>
+
+  <!-- Import the shared tests .props file -->
+  <Import Project="$(MSBuildThisFileDirectory)..\msbuild\props\SixLabors.Tests.props"/>
+  
+  <!-- Import the solution .props file. -->
+  <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props"/>
+
+</Project>

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <!-- Import the shared tests .targets file -->
+  <Import Project="$(MSBuildThisFileDirectory)..\msbuild\targets\SixLabors.Tests.targets"/>
+
+  <!-- Import the solution .targets file. -->
+  <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.targets"/>
+
+</Project>

--- a/tests/SharedInfrastructure.Tests/DebugGuardTests.cs
+++ b/tests/SharedInfrastructure.Tests/DebugGuardTests.cs
@@ -145,9 +145,7 @@ namespace SharedInfrastructure.Tests
 
         [Fact]
         public void MustBeLessThan_IsLess_ThrowsNoException()
-        {
-            DebugGuard.MustBeLessThan(0, 1, "myParamName");
-        }
+            => DebugGuard.MustBeLessThan(0, 1, "myParamName");
 
         [Theory]
         [InlineData(2, 1)]
@@ -165,9 +163,7 @@ namespace SharedInfrastructure.Tests
         [InlineData(0, 1)]
         [InlineData(1, 1)]
         public void MustBeLessThanOrEqualTo_IsLessOrEqual_ThrowsNoException(int value, int max)
-        {
-            DebugGuard.MustBeLessThanOrEqualTo(value, max, "myParamName");
-        }
+            => DebugGuard.MustBeLessThanOrEqualTo(value, max, "myParamName");
 
         [Fact]
         public void MustBeLessThanOrEqualTo_IsGreater_ThrowsNoException()
@@ -180,9 +176,7 @@ namespace SharedInfrastructure.Tests
 
         [Fact]
         public void MustBeGreaterThan_IsGreater_ThrowsNoException()
-        {
-            DebugGuard.MustBeGreaterThan(2, 1, "myParamName");
-        }
+            => DebugGuard.MustBeGreaterThan(2, 1, "myParamName");
 
         [Theory]
         [InlineData(1, 2)]
@@ -200,9 +194,7 @@ namespace SharedInfrastructure.Tests
         [InlineData(2, 1)]
         [InlineData(1, 1)]
         public void MustBeGreaterThanOrEqualTo_IsGreaterOrEqual_ThrowsNoException(int value, int min)
-        {
-            DebugGuard.MustBeGreaterThanOrEqualTo(value, min, "myParamName");
-        }
+            => DebugGuard.MustBeGreaterThanOrEqualTo(value, min, "myParamName");
 
         [Fact]
         public void MustBeGreaterThanOrEqualTo_IsLess_ThrowsNoException()
@@ -218,9 +210,7 @@ namespace SharedInfrastructure.Tests
         [InlineData(new int[] { 1, 2 }, 1)]
         [InlineData(new int[] { 1, 2 }, 2)]
         public void MustBeSizedAtLeast_Array_LengthIsGreaterOrEqual_ThrowsNoException(int[] value, int minLength)
-        {
-            DebugGuard.MustBeSizedAtLeast<int>(value, minLength, "myParamName");
-        }
+            => DebugGuard.MustBeSizedAtLeast<int>(value, minLength, "myParamName");
 
         [Fact]
         public void MustBeSizedAtLeast_Array_LengthIsLess_ThrowsException()

--- a/tests/SharedInfrastructure.Tests/GuardTests.cs
+++ b/tests/SharedInfrastructure.Tests/GuardTests.cs
@@ -125,9 +125,7 @@ namespace SharedInfrastructure.Tests
 
         [Fact]
         public void MustBeLessThan_IsLess_ThrowsNoException()
-        {
-            Guard.MustBeLessThan(0, 1, "myParamName");
-        }
+            => Guard.MustBeLessThan(0, 1, "myParamName");
 
         [Theory]
         [InlineData(2, 1)]
@@ -145,9 +143,7 @@ namespace SharedInfrastructure.Tests
         [InlineData(0, 1)]
         [InlineData(1, 1)]
         public void MustBeLessThanOrEqualTo_IsLessOrEqual_ThrowsNoException(int value, int max)
-        {
-            Guard.MustBeLessThanOrEqualTo(value, max, "myParamName");
-        }
+            => Guard.MustBeLessThanOrEqualTo(value, max, "myParamName");
 
         [Fact]
         public void MustBeLessThanOrEqualTo_IsGreater_ThrowsNoException()
@@ -160,10 +156,7 @@ namespace SharedInfrastructure.Tests
         }
 
         [Fact]
-        public void MustBeGreaterThan_IsGreater_ThrowsNoException()
-        {
-            Guard.MustBeGreaterThan(2, 1, "myParamName");
-        }
+        public void MustBeGreaterThan_IsGreater_ThrowsNoException() => Guard.MustBeGreaterThan(2, 1, "myParamName");
 
         [Theory]
         [InlineData(1, 2)]
@@ -181,9 +174,7 @@ namespace SharedInfrastructure.Tests
         [InlineData(2, 1)]
         [InlineData(1, 1)]
         public void MustBeGreaterThanOrEqualTo_IsGreaterOrEqual_ThrowsNoException(int value, int min)
-        {
-            Guard.MustBeGreaterThanOrEqualTo(value, min, "myParamName");
-        }
+            => Guard.MustBeGreaterThanOrEqualTo(value, min, "myParamName");
 
         [Fact]
         public void MustBeGreaterThanOrEqualTo_IsLess_ThrowsNoException()
@@ -200,9 +191,7 @@ namespace SharedInfrastructure.Tests
         [InlineData(2, 1, 3)]
         [InlineData(3, 1, 3)]
         public void MustBeBetweenOrEqualTo_IsBetweenOrEqual_ThrowsNoException(int value, int min, int max)
-        {
-            Guard.MustBeBetweenOrEqualTo(value, min, max, "myParamName");
-        }
+            => Guard.MustBeBetweenOrEqualTo(value, min, max, "myParamName");
 
         [Theory]
         [InlineData(0, 1, 3)]
@@ -220,9 +209,7 @@ namespace SharedInfrastructure.Tests
         [InlineData(2, 1)]
         [InlineData(2, 2)]
         public void MustBeSizedAtLeast_Array_LengthIsGreaterOrEqual_ThrowsNoException(int valueLength, int minLength)
-        {
-            Guard.MustBeSizedAtLeast<int>(new int[valueLength], minLength, "myParamName");
-        }
+            => Guard.MustBeSizedAtLeast<int>(new int[valueLength], minLength, "myParamName");
 
         [Fact]
         public void MustBeSizedAtLeast_Array_LengthIsLess_ThrowsException()

--- a/tests/SharedInfrastructure.Tests/MathFTests.cs
+++ b/tests/SharedInfrastructure.Tests/MathFTests.cs
@@ -10,86 +10,58 @@ namespace SharedInfrastructure.Tests
     {
         [Fact]
         public void MathF_PI_Is_Equal()
-        {
-            Assert.Equal(MathF.PI, (float)Math.PI);
-        }
+            => Assert.Equal(MathF.PI, (float)Math.PI);
 
         [Fact]
         public void MathF_Ceililng_Is_Equal()
-        {
-            Assert.Equal(MathF.Ceiling(0.3333F), (float)Math.Ceiling(0.3333F));
-        }
+            => Assert.Equal(MathF.Ceiling(0.3333F), (float)Math.Ceiling(0.3333F));
 
         [Fact]
         public void MathF_Cos_Is_Equal()
-        {
-            Assert.Equal(MathF.Cos(0.3333F), (float)Math.Cos(0.3333F));
-        }
+            => Assert.Equal(MathF.Cos(0.3333F), (float)Math.Cos(0.3333F));
 
         [Fact]
         public void MathF_Abs_Is_Equal()
-        {
-            Assert.Equal(MathF.Abs(-0.3333F), (float)Math.Abs(-0.3333F));
-        }
+            => Assert.Equal(MathF.Abs(-0.3333F), (float)Math.Abs(-0.3333F));
 
         [Fact]
         public void MathF_Atan2_Is_Equal()
-        {
-            Assert.Equal(MathF.Atan2(1.2345F, 1.2345F), (float)Math.Atan2(1.2345F, 1.2345F));
-        }
+            => Assert.Equal(MathF.Atan2(1.2345F, 1.2345F), (float)Math.Atan2(1.2345F, 1.2345F));
 
         [Fact]
         public void MathF_Exp_Is_Equal()
-        {
-            Assert.Equal(MathF.Exp(1.2345F), (float)Math.Exp(1.2345F));
-        }
+            => Assert.Equal(MathF.Exp(1.2345F), (float)Math.Exp(1.2345F));
 
         [Fact]
         public void MathF_Floor_Is_Equal()
-        {
-            Assert.Equal(MathF.Floor(1.2345F), (float)Math.Floor(1.2345F));
-        }
+            => Assert.Equal(MathF.Floor(1.2345F), (float)Math.Floor(1.2345F));
 
         [Fact]
         public void MathF_Min_Is_Equal()
-        {
-            Assert.Equal(MathF.Min(1.2345F, 5.4321F), (float)Math.Min(1.2345F, 5.4321F));
-        }
+            => Assert.Equal(MathF.Min(1.2345F, 5.4321F), (float)Math.Min(1.2345F, 5.4321F));
 
         [Fact]
         public void MathF_Max_Is_Equal()
-        {
-            Assert.Equal(MathF.Max(1.2345F, 5.4321F), (float)Math.Max(1.2345F, 5.4321F));
-        }
+            => Assert.Equal(MathF.Max(1.2345F, 5.4321F), (float)Math.Max(1.2345F, 5.4321F));
 
         [Fact]
         public void MathF_Pow_Is_Equal()
-        {
-            Assert.Equal(MathF.Pow(1.2345F, 5.4321F), (float)Math.Pow(1.2345F, 5.4321F));
-        }
+            => Assert.Equal(MathF.Pow(1.2345F, 5.4321F), (float)Math.Pow(1.2345F, 5.4321F));
 
         [Fact]
         public void MathF_Round_Is_Equal()
-        {
-            Assert.Equal(MathF.Round(1.2345F), (float)Math.Round(1.2345F));
-        }
+            => Assert.Equal(MathF.Round(1.2345F), (float)Math.Round(1.2345F));
 
         [Fact]
         public void MathF_Round_With_Midpoint_Is_Equal()
-        {
-            Assert.Equal(MathF.Round(1.2345F, MidpointRounding.AwayFromZero), (float)Math.Round(1.2345F, MidpointRounding.AwayFromZero));
-        }
+            => Assert.Equal(MathF.Round(1.2345F, MidpointRounding.AwayFromZero), (float)Math.Round(1.2345F, MidpointRounding.AwayFromZero));
 
         [Fact]
         public void MathF_Sin_Is_Equal()
-        {
-            Assert.Equal(MathF.Sin(1.2345F), (float)Math.Sin(1.2345F));
-        }
+            => Assert.Equal(MathF.Sin(1.2345F), (float)Math.Sin(1.2345F));
 
         [Fact]
         public void MathF_Sqrt_Is_Equal()
-        {
-            Assert.Equal(MathF.Sqrt(2F), (float)Math.Sqrt(2F));
-        }
+            => Assert.Equal(MathF.Sqrt(2F), (float)Math.Sqrt(2F));
     }
 }

--- a/tests/SharedInfrastructure.Tests/SharedInfrastructure.Tests.csproj
+++ b/tests/SharedInfrastructure.Tests/SharedInfrastructure.Tests.csproj
@@ -1,101 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;netcoreapp2.0;net472;net46</TargetFrameworks>
     <AssemblyName>SharedInfrastructure.Tests</AssemblyName>
     <RootNamespace>SharedInfrastructure.Tests</RootNamespace>
-    <IsPackable>false</IsPackable>
-    <CodeAnalysisRuleSet>..\..\SixLabors.Tests.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-
-  <!--
-    https://apisof.net/
-    +===================+=======+==========+=====================+=============+=================+====================+==============+=========+============|
-    | SUPPORTS          | MATHF | HASHCODE | EXTENDED_INTRINSICS | SPAN_STREAM | ENCODING_STRING | RUNTIME_INTRINSICS | CODECOVERAGE | HOTPATH | CREATESPAN |
-    +===================+=======+==========+=====================+=============+=================+====================+==============+=========|============|
-    | netcoreapp3.1     |   Y   |    Y     |         Y           |      Y      |        Y        |        Y           |      Y       |    Y    |      Y     |
-    | netcoreapp2.1     |   Y   |    Y     |         Y           |      Y      |        Y        |        N           |      Y       |    N    |      Y     |
-    | netcoreapp2.0     |   Y   |    N     |         N           |      N      |        N        |        N           |      Y       |    N    |      Y     |
-    | netstandard2.1    |   Y   |    Y     |         N           |      Y      |        Y        |        N           |      Y       |    N    |      Y     |
-    | netstandard2.0    |   N   |    N     |         N           |      N      |        N        |        N           |      Y       |    N    |      N     |
-    | netstandard1.3    |   N   |    N     |         N           |      N      |        N        |        N           |      N       |    N    |      N     |
-    | net472            |   N   |    N     |         Y           |      N      |        N        |        N           |      Y       |    N    |      N     |
-    +===================+=======+==========+=====================+=============+=================+====================+==============+=========|============|
-    -->
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_HASHCODE</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_SPAN_STREAM</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_ENCODING_STRING</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_RUNTIME_INTRINSICS</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_HOTPATH</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_CREATESPAN</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_HASHCODE</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_SPAN_STREAM</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_ENCODING_STRING</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_CREATESPAN</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_CREATESPAN</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_HASHCODE</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_SPAN_STREAM</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_ENCODING_STRING</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_CREATESPAN</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
-    <!--dotnet tools does not have an x86 runner. You have to use separate SDKs-->
-    <!--https://github.com/actions/setup-dotnet/issues/72-->
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <!--Don't update the SDK. It causes xunit to break for netcore 2.0-->
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp2.0' ">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0" PrivateAssets="All"/>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="System.Buffers" Version="4.5.0" />
-    <PackageReference Include="System.Memory" Version="4.5.3" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-
-    <AdditionalFiles Include="..\..\stylecop.json" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" ('$(TargetFramework)' != 'netcoreapp3.1') AND '$(TargetFramework)' != 'netcoreapp2.1' ">
-    <PackageReference Include="System.Buffers" Version="4.5.0" />
-    <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/SharedInfrastructure/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
- Adds updated documented `editorconfig` based upon https://github.com/RehanSaeed/EditorConfig/
- Updates code analysis rulesets to match and make them more compatible with the UI editor.
- Adds Global/Src/Tests `.props` and `.targets` files containing defaults to be shared across our repositories. 

I'm been testing this against a local version of ImageSharp. We end up with a much simpler setup in the our imports.

For example:
https://github.com/SixLabors/ImageSharp/blob/master/Directory.Build.props

becomes.

```xml
<?xml version="1.0" encoding="utf-8"?>
<Project>

  <!--
    Directory.Build.props is automatically picked up and imported by
    Microsoft.Common.props. This file needs to exist, even if empty so that
    files in the parent directory tree, with the same name, are not imported
    instead. The import fairly early and only Sdk.props will have been imported
    beforehand. We also don't need to add ourselves to MSBuildAllProjects, as
    that is done by the file that imports us.
  -->

  <PropertyGroup>
    <!-- This MUST be defined before importing props. -->
    <SixLaborsSolutionDirectory>$(MSBuildThisFileDirectory)</SixLaborsSolutionDirectory>
  </PropertyGroup>

  <!-- Import the shared global .props file -->
  <Import Project="$(MSBuildThisFileDirectory)shared-infrastructure\msbuild\props\SixLabors.Global.props" />

</Project>

```
<!-- Thanks for contributing to SharedInfrastructure! -->
