### PR TITLE
Treat TIFF images as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -107,6 +107,8 @@
 *.tga               binary
 *.ttc               binary
 *.ttf               binary
+*.tif               binary
+*.tiff              binary
 *.webp              binary
 *.woff              binary
 *.woff2             binary


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/SharedInfrastructure/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

As the title says: TIFF images should be treated as binary.