### PR TITLE
Add SUPPORTS_GCMEMORYINFO

### DIFF
--- a/msbuild/props/SixLabors.Global.props
+++ b/msbuild/props/SixLabors.Global.props
@@ -121,19 +121,18 @@
 
   <!-- Define target framework specific constants.
     https://apisof.net/
-    +===================+=======+==========+=====================+=============+=================+====================+==============+=========+============|===============|
-    | SUPPORTS          | MATHF | HASHCODE | EXTENDED_INTRINSICS | SPAN_STREAM | ENCODING_STRING | RUNTIME_INTRINSICS | CODECOVERAGE | HOTPATH | CREATESPAN | BITOPERATIONS |
-    +===================+=======+==========+=====================+=============+=================+====================+==============+=========|============|===============|
-    | >=netcoreapp3.1   |   Y   |    Y     |         Y           |      Y      |        Y        |        Y           |      Y       |    Y    |      Y     |       Y       |
-    | netcoreapp2.1     |   Y   |    Y     |         Y           |      Y      |        Y        |        N           |      Y       |    N    |      Y     |       N       |
-    | netcoreapp2.0     |   Y   |    N     |         N           |      N      |        N        |        N           |      Y       |    N    |      Y     |       N       |
-    | netstandard2.1    |   Y   |    Y     |         N           |      Y      |        Y        |        N           |      Y       |    N    |      Y     |       N       |
-    | netstandard2.0    |   N   |    N     |         N           |      N      |        N        |        N           |      Y       |    N    |      N     |       N       |
-    | netstandard1.3    |   N   |    N     |         N           |      N      |        N        |        N           |      N       |    N    |      N     |       N       |
-    | net472, net48     |   N   |    N     |         Y           |      N      |        N        |        N           |      Y       |    N    |      N     |       N       |
-    +===================+=======+==========+=====================+=============+=================+====================+==============+=========|============|===============|
-    -->
-  <Choose>
+    +===================+=======+==========+=====================+=============+=================+====================+==============+=========+============|===============|==============|
+    | SUPPORTS          | MATHF | HASHCODE | EXTENDED_INTRINSICS | SPAN_STREAM | ENCODING_STRING | RUNTIME_INTRINSICS | CODECOVERAGE | HOTPATH | CREATESPAN | BITOPERATIONS | GCMEMORYINFO |
+    +===================+=======+==========+=====================+=============+=================+====================+==============+=========|============|===============|==============|
+    | >=netcoreapp3.1   |   Y   |    Y     |         Y           |      Y      |        Y        |        Y           |      Y       |    Y    |      Y     |       Y       |       Y      |
+    | netcoreapp2.1     |   Y   |    Y     |         Y           |      Y      |        Y        |        N           |      Y       |    N    |      Y     |       N       |       N      |
+    | netcoreapp2.0     |   Y   |    N     |         N           |      N      |        N        |        N           |      Y       |    N    |      Y     |       N       |       N      |
+    | netstandard2.1    |   Y   |    Y     |         N           |      Y      |        Y        |        N           |      Y       |    N    |      Y     |       N       |       N      |
+    | netstandard2.0    |   N   |    N     |         N           |      N      |        N        |        N           |      Y       |    N    |      N     |       N       |       N      |
+    | netstandard1.3    |   N   |    N     |         N           |      N      |        N        |        N           |      N       |    N    |      N     |       N       |       N      |
+    | net472, net48     |   N   |    N     |         Y           |      N      |        N        |        N           |      Y       |    N    |      N     |       N       |       N      |
+    +===================+=======+==========+=====================+=============+=================+====================+==============+=========|============|===============|==============|
+    -->  <Choose>
     <When Condition="'$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net48'">
       <PropertyGroup>
         <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS</DefineConstants>
@@ -187,8 +186,8 @@
         <DefineConstants>$(DefineConstants);SUPPORTS_HOTPATH</DefineConstants>
         <DefineConstants>$(DefineConstants);SUPPORTS_CREATESPAN</DefineConstants>
         <DefineConstants>$(DefineConstants);SUPPORTS_BITOPERATIONS</DefineConstants>
+        <DefineConstants>$(DefineConstants);SUPPORTS_GCMEMORYINFO</DefineConstants>
       </PropertyGroup>
     </When>
   </Choose>
-
 </Project>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/SharedInfrastructure/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
Detect support of `GCMemoryInfo` API-s: https://apisof.net/catalog/7c817240-aab2-6919-682b-af49402fc96b