### PR TITLE
Add licensing package reference transform targets

### DIFF
--- a/SharedInfrastructure.sln
+++ b/SharedInfrastructure.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29709.97
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36310.24
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharedInfrastructure.Tests", "tests\SharedInfrastructure.Tests\SharedInfrastructure.Tests.csproj", "{1664B46A-D99F-4C66-9424-A3A17C926A4C}"
 EndProject
@@ -66,10 +66,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "targets", "targets", "{A411
 	EndProjectSection
 EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		src\SharedInfrastructure\SharedInfrastructure.projitems*{1664b46a-d99f-4c66-9424-a3a17c926a4c}*SharedItemsImports = 5
-		src\SharedInfrastructure\SharedInfrastructure.projitems*{68a8cc40-6aed-4e96-b524-31b1158fdeea}*SharedItemsImports = 13
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
@@ -94,5 +90,9 @@ Global
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CDD6BE8E-01A1-4A70-AA7E-F1D64E8FA829}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		src\SharedInfrastructure\SharedInfrastructure.projitems*{1664b46a-d99f-4c66-9424-a3a17c926a4c}*SharedItemsImports = 5
+		src\SharedInfrastructure\SharedInfrastructure.projitems*{68a8cc40-6aed-4e96-b524-31b1158fdeea}*SharedItemsImports = 13
 	EndGlobalSection
 EndGlobal

--- a/msbuild/props/SixLabors.Src.props
+++ b/msbuild/props/SixLabors.Src.props
@@ -24,8 +24,6 @@
 
   <!-- 
     Define Environmental conditionals. Determined by environmental settings set in build-and-test.yml 
-    These properties are defined 2X to ensure both MSBuild and Visual Studio (preprocessor directives)
-    can correctly detect them.
     -->
   <PropertyGroup>
     <IsContinuousIntegration Condition="'$(CI)' == 'true'">true</IsContinuousIntegration>
@@ -46,6 +44,19 @@
     <MinVerTagPrefix>v</MinVerTagPrefix>
     <MinVerVerbosity>normal</MinVerVerbosity>
   </PropertyGroup>
+
+  <!-- 
+      Package reference to the license project which is consumed by src projects
+      This is a dev only reference. See the SixLabors.Src.targets file for usage.
+   -->
+  <ItemGroup>
+    <PackageReference
+        Include="SixLabors.Licensing"
+        Version="1.0.0"
+        PrivateAssets="all"
+        GeneratePathProperty="true"
+        Condition="'$(PackageId)' != 'SixLabors.Licensing' and '$(MSBuildProjectName)' != 'SixLabors.Licensing'" />
+  </ItemGroup>
 
   <!-- Package references and additional files which are consumed by src projects. CI Only -->
   <ItemGroup Condition="'$(IsContinuousIntegration)'=='true'">

--- a/msbuild/targets/SixLabors.Src.targets
+++ b/msbuild/targets/SixLabors.Src.targets
@@ -17,4 +17,56 @@
           DestinationFolder="$(SixLaborsSolutionDirectory)" />
   </Target>
 
+  <!--
+      This target is responsible for copying licensing files to the licensing NuGet package
+      to our build output.
+      See SixLabors.Src.props for the package references.
+      Hook into NuGet pack.
+  -->
+  <PropertyGroup>
+    <TargetsForTfmSpecificContentInPackage>
+      $(TargetsForTfmSpecificContentInPackage);_SixLabors_AddLicensingFiles
+    </TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+  <!-- Add files per TFM from the *package cache* only -->
+  <Target Name="_SixLabors_AddLicensingFiles"
+          Condition="'$(IsPackable)'=='true'
+                 and '$(TargetFramework)'!=''
+                 and $([System.String]::Copy('$(PackageId)').StartsWith('SixLabors.'))
+                 and '$(PackageId)'!='SixLabors.Licensing'
+                 and '$(PkgSixLabors_Licensing)'!=''">
+
+    <ItemGroup>
+      <!-- Rename the validator template into the consuming package -->
+      <TfmSpecificPackageFile Include="$(PkgSixLabors_Licensing)\build\SixLabors.ValidateLicense.targets"
+                              Condition="Exists('$(PkgSixLabors_Licensing)\build\SixLabors.ValidateLicense.targets')">
+        <PackagePath>build\$(PackageId).targets</PackagePath>
+      </TfmSpecificPackageFile>
+
+      <!-- dotnet MSBuild task -->
+      <TfmSpecificPackageFile Include="$(PkgSixLabors_Licensing)\build\net8.0\SixLabors.Licensing.dll"
+                              Condition="Exists('$(PkgSixLabors_Licensing)\build\net8.0\SixLabors.Licensing.dll')">
+        <PackagePath>build\net8.0\SixLabors.Licensing.dll</PackagePath>
+      </TfmSpecificPackageFile>
+
+      <!-- VS/CLR4 MSBuild task -->
+      <TfmSpecificPackageFile Include="$(PkgSixLabors_Licensing)\build\net472\SixLabors.Licensing.dll"
+                              Condition="Exists('$(PkgSixLabors_Licensing)\build\net472\SixLabors.Licensing.dll')">
+        <PackagePath>build\net472\SixLabors.Licensing.dll</PackagePath>
+      </TfmSpecificPackageFile>
+    </ItemGroup>
+  </Target>
+
+  <!-- Hard fail if the package path isn't resolvable -->
+  <Target Name="FailIfLicensingPathMissing" BeforeTargets="Pack"
+          Condition="'$(IsPackable)'=='true'
+                 and '$(TargetFramework)'!=''
+                 and $([System.String]::Copy('$(PackageId)').StartsWith('SixLabors.'))
+                 and '$(PackageId)'!='SixLabors.Licensing'
+                 and ( '$(PkgSixLabors_Licensing)'=='' 
+                       or !Exists('$(PkgSixLabors_Licensing)\build\net8.0\SixLabors.Licensing.dll') )">
+    <Error Text="Licensing task not found under $(PkgSixLabors_Licensing)\build\net8.0. Ensure the dev-only PackageReference (GeneratePathProperty='true') is present and restore ran." />
+  </Target>
+
 </Project>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/SharedInfrastructure/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

Adds the relevant props/targets to allow build time validation of Six Labors packages.

<!-- Thanks for contributing to SharedInfrastructure! -->
