### PR TITLE
Add astc files so they are checked in with LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -126,6 +126,7 @@
 *.dds               filter=lfs diff=lfs merge=lfs -text
 *.ktx               filter=lfs diff=lfs merge=lfs -text
 *.ktx2              filter=lfs diff=lfs merge=lfs -text
+*.astc              filter=lfs diff=lfs merge=lfs -text
 *.pam               filter=lfs diff=lfs merge=lfs -text
 *.pbm               filter=lfs diff=lfs merge=lfs -text
 *.pgm               filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/SharedInfrastructure/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
[Adding ASTC compression support in ImageSharp.Textures](https://github.com/SixLabors/ImageSharp.Textures/pull/37) requires checking in some .astc test data files. This change just ensures that astc files are checked in with LFS and prevents changes to the attributes file in ImageSharp.Textures from being overwritten
